### PR TITLE
Fix req_host calculation

### DIFF
--- a/lambda_src/drivers/process_google.py
+++ b/lambda_src/drivers/process_google.py
@@ -1,7 +1,8 @@
 from json import loads
 
-from google.oauth2 import service_account, credentials
-from googleapiclient.discovery import build
+from google.oauth2 import credentials, service_account  # type: ignore
+from googleapiclient.discovery import build  # type: ignore
+
 from ..vault import decrypt_if_encrypted
 
 
@@ -21,9 +22,8 @@ def process_row(
         creds = credentials.Credentials.from_authorized_user_info(
             loads(decrypt_if_encrypted(authorized_user_info)), scopes
         )
-
     else:
-        c = service_account.Credentials.from_service_account_info(
+        c = service_account.Credentials.from_service_account_info( # asdf
             loads(decrypt_if_encrypted(service_account_info))
         )
         if subject is None or without_subject:

--- a/lambda_src/drivers/process_google.py
+++ b/lambda_src/drivers/process_google.py
@@ -23,7 +23,7 @@ def process_row(
             loads(decrypt_if_encrypted(authorized_user_info)), scopes
         )
     else:
-        c = service_account.Credentials.from_service_account_info( # asdf
+        c = service_account.Credentials.from_service_account_info(
             loads(decrypt_if_encrypted(service_account_info))
         )
         if subject is None or without_subject:

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -38,14 +38,7 @@ def process_row(
     if not base_url and not url:
         raise ValueError('Missing required parameter. Need one of url or base-url.')
 
-    req_url = (
-        base_url
-        if not url
-        else url
-        if url.startswith(base_url)
-        else base_url + url
-    )
-
+    req_url = url if url.startswith(base_url) else base_url + url
     u = urlparse(req_url)
     if u.scheme != 'https':
         raise ValueError('URL scheme must be HTTPS.')

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -5,7 +5,7 @@ from json import JSONDecodeError, dumps, loads
 from re import match
 from typing import Any, Dict, List, Optional, Text, Union
 from urllib.error import HTTPError, URLError
-from urllib.parse import parse_qsl
+from urllib.parse import parse_qsl, urlparse
 from urllib.request import Request, urlopen
 
 from ..utils import LOG, parse_header_links, pick
@@ -37,15 +37,10 @@ def process_row(
 ):
     if url:
         req_url = url if url.startswith(base_url) else base_url + url
-        m = match(r'^https://([^/]+)(.*)$', req_url)
-        if m:
-            req_host, req_path = m.groups()
-        else:
-            raise RuntimeError('url must start with https://')
     else:
-        req_host = base_url
         req_url = base_url
 
+    req_host = urlparse(req_url).hostname
     req_kwargs = parse_header_dict(kwargs)
     req_headers = {
         k: v.format(**req_kwargs)

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -37,6 +37,7 @@ def process_row(
 ):
     if not base_url and not url:
         raise ValueError('Missing required parameter. Need one of url or base-url.')
+
     req_url = (
         base_url
         if not url

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -41,11 +41,9 @@ def process_row(
     req_url = (
         base_url
         if not url
-        else (
-            url
-            if url.startswith(base_url)
-            else base_url + url
-        )
+        else url
+        if url.startswith(base_url)
+        else base_url + url
     )
 
     u = urlparse(req_url)
@@ -76,11 +74,9 @@ def process_row(
         req_auth = (
             loads(auth)
             if auth.startswith('{')
-            else (
-                parse_header_dict(auth)
-                if auth
-                else {}
-            )
+            else parse_header_dict(auth)
+            if auth
+            else {}
         )
 
         if 'host' in req_auth and not req_host:

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -35,12 +35,15 @@ def process_row(
     results_path: Text = '',
     destination_uri: Text = '',
 ):
-    if url:
-        req_url = url if url.startswith(base_url) else base_url + url
-    else:
-        req_url = base_url
+    if not base_url and not url:
+        raise ValueError('Missing required parameter. Need one of url or base-url.')
+    req_url = base_url if not url else url if url.startswith(base_url) else base_url + url
 
-    req_host = urlparse(req_url).hostname
+    u = urlparse(req_url)
+    if u.scheme != 'https':
+        raise ValueError('URL scheme must be HTTPS.')
+
+    req_host = u.hostname
     req_kwargs = parse_header_dict(kwargs)
     req_headers = {
         k: v.format(**req_kwargs)

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -37,7 +37,15 @@ def process_row(
 ):
     if not base_url and not url:
         raise ValueError('Missing required parameter. Need one of url or base-url.')
-    req_url = base_url if not url else url if url.startswith(base_url) else base_url + url
+    req_url = (
+        base_url
+        if not url
+        else (
+            url
+            if url.startswith(base_url)
+            else base_url + url
+        )
+    )
 
     u = urlparse(req_url)
     if u.scheme != 'https':
@@ -50,9 +58,11 @@ def process_row(
         for k, v in (
             loads(headers)
             if headers.startswith('{')
-            else parse_header_dict(headers)
-            if headers
-            else {}
+            else (
+                parse_header_dict(headers)
+                if headers
+                else {}
+            )
         ).items()
     }
 
@@ -65,9 +75,11 @@ def process_row(
         req_auth = (
             loads(auth)
             if auth.startswith('{')
-            else parse_header_dict(auth)
-            if auth
-            else {}
+            else (
+                parse_header_dict(auth)
+                if auth
+                else {}
+            )
         )
 
         if 'host' in req_auth and not req_host:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,8 @@
 -r requirements.txt
 black
+google-api-python-client-stubs
 mypy
 pytest
 botocore
 boto3
+boto3-stubs


### PR DESCRIPTION
Use urllib parse to get the hostname out of req_url rather than url or base-url

The bug: 
```bash
with 'base-url'= 'https://management.azure.com/subscriptions/f...... passed we get an error:
{
  "body": {
    "error": {
      "code": "AuthenticationFailed",
      "message": "Authentication failed. The 'Authorization' header is missing."
    }
  },
  "error": "HTTPError",
  "reason": "Unauthorized",
  "status": 401,
  "url": https://management.azure.com/subscriptions/f7032e9f-033a-4259-b561-252a7864705d/providers/Microsoft.Insights/eventtypes/management/values?%24filter=eventTimestamp%20ge%20%272021-08-25T00%3A36%3A37.6407898Z%27&api-version=2015-04-01
}

With 'url'= 'https://management.azure.com/subscriptions/f……. we don't get error.
```

**_Tests_**:
Tested on test snowflake instance with below definition which wouldn't have worked based on the above bug.
```sql
CREATE OR REPLACE SECURE EXTERNAL FUNCTION DB.SCHEMA.abuseipdb_check_ip(
    ip STRING,
    max_age_in_days NUMBER,
    verbose STRING
)
RETURNS VARIANT
RETURNS NULL ON NULL INPUT
VOLATILE
COMMENT='https://docs.abuseipdb.com/#check-endpoint'
API_INTEGRATION="test_geff_api_integration"
HEADERS=(
    'auth' = '{"headers": {"Key": "<redacted>"}, "host":"api.abuseipdb.com"}'
    -- 'auth' = 'arn:aws:secretsmanager:us-west-2:111122223333:secret:aes128-1a2b3c'
    'params'='ipAddress={0}&maxAgeInDays={1}&{2}'
    'headers'='{"Accept": "application/json"}'
    'base-url'='https://api.abuseipdb.com/api/v2/check'
    'results-path' = 'data'
)
AS 'https://<api-id>.execute-api.us-west-2.amazonaws.com/dev/https'
;
```