### PR TITLE
Allow cursor to be a URL

### DIFF
--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -179,15 +179,17 @@ def process_row(
 
         if req_cursor and isinstance(result, list):
             row_data += result
-            if req_cursor.startswith('https://'):
-                next_url = req_cursor
+  
+            if ':' in req_cursor:
+                cursor_path, cursor_param = req_cursor.rsplit(':', 1)
             else:
-                if ':' in req_cursor:
-                    cursor_path, cursor_param = req_cursor.rsplit(':', 1)
-                else:
-                    cursor_path = req_cursor
-                    cursor_param = cursor_path.split('.')[-1]
-                cursor_value = pick(cursor_path, response)
+                cursor_path = req_cursor
+                cursor_param = cursor_path.split('.')[-1]
+            cursor_value = pick(cursor_path, response)
+
+            if cursor_value.startswith('https://'):
+                next_url = cursor_value
+            else:
                 next_url = (
                     f'{req_url}&{cursor_param}={cursor_value}' if cursor_value else None
                 )

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -185,11 +185,12 @@ def process_row(
             else:
                 cursor_path = req_cursor
                 cursor_param = cursor_path.split('.')[-1]
+
             cursor_value = pick(cursor_path, response)
 
             next_url = (
                 cursor_value
-                if cursor_value.startswith('https://')
+                if cursor_value and cursor_value.startswith('https://')
                 else f'{req_url}&{cursor_param}={cursor_value}'
                 if cursor_value
                 else None

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -179,15 +179,18 @@ def process_row(
 
         if req_cursor and isinstance(result, list):
             row_data += result
-            if ':' in req_cursor:
-                cursor_path, cursor_param = req_cursor.rsplit(':', 1)
+            if cursor.startswith(req_cursor):
+                next_url = req_cursor
             else:
-                cursor_path = req_cursor
-                cursor_param = cursor_path.split('.')[-1]
-            cursor_value = pick(cursor_path, response)
-            next_url = (
-                f'{req_url}&{cursor_param}={cursor_value}' if cursor_value else None
-            )
+                if ':' in req_cursor:
+                    cursor_path, cursor_param = req_cursor.rsplit(':', 1)
+                else:
+                    cursor_path = req_cursor
+                    cursor_param = cursor_path.split('.')[-1]
+                cursor_value = pick(cursor_path, response)
+                next_url = (
+                    f'{req_url}&{cursor_param}={cursor_value}' if cursor_value else None
+                )
         elif links_headers and isinstance(result, list):
             row_data += result
             link_dict: Dict[Any, Any] = next(

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -179,7 +179,7 @@ def process_row(
 
         if req_cursor and isinstance(result, list):
             row_data += result
-            if cursor.startswith(req_cursor):
+            if cursor.startswith('https://'):
                 next_url = req_cursor
             else:
                 if ':' in req_cursor:

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -187,12 +187,13 @@ def process_row(
                 cursor_param = cursor_path.split('.')[-1]
             cursor_value = pick(cursor_path, response)
 
-            if cursor_value.startswith('https://'):
-                next_url = cursor_value
-            else:
-                next_url = (
-                    f'{req_url}&{cursor_param}={cursor_value}' if cursor_value else None
-                )
+            next_url = (
+                cursor_value
+                if cursor_value.startswith('https://')
+                else f'{req_url}&{cursor_param}={cursor_value}'
+                if cursor_value
+                else None
+            )
         elif links_headers and isinstance(result, list):
             row_data += result
             link_dict: Dict[Any, Any] = next(

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -179,7 +179,7 @@ def process_row(
 
         if req_cursor and isinstance(result, list):
             row_data += result
-            if cursor.startswith('https://'):
+            if req_cursor.startswith('https://'):
                 next_url = req_cursor
             else:
                 if ':' in req_cursor:


### PR DESCRIPTION
Allow cursor to be a URL.

Support pagination using cursors of the type below:

```json
{
  "value": [
    "item1",
    "item2",
    "item3"
  ],
  "nextLink": "https://management.azure.com/{operation}?api-version={version}&%24skiptoken={token}"
}
```
The usage would be:

```sql
CREATE OR REPLACE SECURE EXTERNAL FUNCTION azure_api_logs()
RETURNS VARIANT
RETURNS NULL ON NULL INPUT
VOLATILE
MAX_BATCH_ROWS=1
API_INTEGRATION=test_geff_api_integration
HEADERS=(
    'url' = 'https://management.azure.com/subscriptions/f7032e9f-033a-4259-b561-252a7864705d/providers/Microsoft.Insights/eventtypes/management/values?%24filter=eventTimestamp%20ge%20%272021-08-25T00%3A36%3A37.6407898Z%27&api-version=2015-04-01'
    'auth'     = '{"host":"management.azure.com", "authorization":" Bearer dummy"}'
    'cusror'   = 'https://management.azure.com/{operation}?api-version={version}&%24skiptoken={token}'
)
AS 'https://a1b2c3d4.execute-api.us-east-2.amazonaws.com/prod/https'
;

```
