### PR TITLE
Refactors to https driver

### DIFF
--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -72,10 +72,13 @@ def process_row(
         auth_host = req_auth.get('host')
 
         # We reject the request if the 'auth' is present but doesn't match the pinned host.
-        if auth_host and auth_host != req_host:
+        if auth_host and req_host and auth_host != req_host:
             raise ValueError(
                 "Requests can only be made to host provided in the auth header."
             )
+        # If the URL is missing a hostname, use the host from the auth dictionary
+        elif auth_host and not req_host:
+            req_host = req_auth['host']
         # We make unauthenticated request if the 'host' key is missing.
         elif not auth_host:
             raise ValueError(f"'auth' missing the 'host' key.")

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -75,8 +75,8 @@ def process_row(
         if not auth_host:
             LOG.info(f"'auth' missing the 'host' key.")
 
-        # We reject the request if the 'auth' doesn't match the pinned host.
-        if auth_host != req_host:
+        # We reject the request if the 'auth' is present but doesn't match the pinned host.
+        if auth_host and auth_host != req_host:
             raise ValueError(
                 "Requests can only be made to host provided in the auth header."
             )

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -71,16 +71,15 @@ def process_row(
         )
         auth_host = req_auth.get('host')
 
-        # We make unauthenticated request if the 'host' key is missing.
-        if not auth_host:
-            LOG.info(f"'auth' missing the 'host' key.")
-
         # We reject the request if the 'auth' is present but doesn't match the pinned host.
         if auth_host and auth_host != req_host:
             raise ValueError(
                 "Requests can only be made to host provided in the auth header."
             )
-
+        # We make unauthenticated request if the 'host' key is missing.
+        elif not auth_host:
+            LOG.info(f"'auth' missing the 'host' key.")
+            pass
         elif 'basic' in req_auth:
             req_headers['Authorization'] = make_basic_header(req_auth['basic'])
         elif 'bearer' in req_auth:

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -59,7 +59,7 @@ def process_row(
     req_headers.setdefault('Accept-Encoding', 'gzip')
 
     # We look for an auth header and if found, we parse it from its encoded format
-    if auth is not None:
+    if auth:
         auth = decrypt_if_encrypted(auth)
 
         req_auth = (

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -78,7 +78,7 @@ def process_row(
             )
         # If the URL is missing a hostname, use the host from the auth dictionary
         elif auth_host and not req_host:
-            req_host = req_auth['host']
+            req_host = auth_host
         # We make unauthenticated request if the 'host' key is missing.
         elif not auth_host:
             raise ValueError(f"'auth' missing the 'host' key.")

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -78,8 +78,7 @@ def process_row(
             )
         # We make unauthenticated request if the 'host' key is missing.
         elif not auth_host:
-            LOG.info(f"'auth' missing the 'host' key.")
-            pass
+            raise ValueError(f"'auth' missing the 'host' key.")
         elif 'basic' in req_auth:
             req_headers['Authorization'] = make_basic_header(req_auth['basic'])
         elif 'bearer' in req_auth:


### PR DESCRIPTION
- Uniform driver pinning interface and error messages
- Uniform `None` checking with SMTP driver

**_Tests_**:
Success test (if `auth` dict has `host` key to pin the host to which we can send auth credentials):
![image](https://user-images.githubusercontent.com/72515998/137416301-90f59fc3-a16b-49db-8f28-821a225ced55.png)

Failure test (if `auth` dict doesn't have the `host` key):
![image](https://user-images.githubusercontent.com/72515998/137416916-18631719-de2f-4f61-8708-f4c7006a042a.png)