### PR TITLE
Add dockerfile to build geff image to run in lambda docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Install git and git clone the geff repo
+RUN yum update -y && \
+    yum install -y git && \
+    rm -Rf /var/cache/yum
+
+COPY lambda_src/ "${LAMBDA_TASK_ROOT}"
+
+COPY requirements.txt "${LAMBDA_TASK_ROOT}"
+
+RUN ls -l "${LAMBDA_TASK_ROOT}"
+
+# Install the function's dependencies using file requirements.txt
+RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to yoaur handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "lambda_function.lambda_handler" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,16 @@ RUN yum update -y && \
     yum install -y git && \
     rm -Rf /var/cache/yum
 
-COPY lambda_src/ "${LAMBDA_TASK_ROOT}"
+RUN mkdir "${LAMBDA_TASK_ROOT}/geff/"
 
-COPY requirements.txt "${LAMBDA_TASK_ROOT}"
+COPY lambda_src/  "${LAMBDA_TASK_ROOT}/geff/"
 
-RUN ls -l "${LAMBDA_TASK_ROOT}"
+COPY requirements.txt  "${LAMBDA_TASK_ROOT}"
+
+RUN ls -l
 
 # Install the function's dependencies using file requirements.txt
 RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 # Set the CMD to yoaur handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "lambda_function.lambda_handler" ]
+CMD [ "geff.lambda_function.lambda_handler" ]

--- a/ecr.sh
+++ b/ecr.sh
@@ -2,7 +2,7 @@
 
 ACCOUNT_ID="<enter account ID>"
 IMAGE_VER=geff:latest
-ECR_HOST="075393536245.dkr.ecr.us-west-2.amazonaws.com"
+ECR_HOST="${ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com"
 
 # Create repo for GEFF docker image
 aws ecr create-repository --repository-name geff --region us-west-2

--- a/ecr.sh
+++ b/ecr.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+ACCOUNT_ID="<enter account ID>"
+IMAGE_VER=geff:latest
+ECR_HOST="075393536245.dkr.ecr.us-west-2.amazonaws.com"
+
+# Create repo for GEFF docker image
+aws ecr create-repository --repository-name geff --region us-west-2
+
+# NOTE: From here all steps need docker desktop to be running.
+
+# Login
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $ECR_HOST
+
+# Docker Build (Needs docker desktop running)
+docker build -t geff .
+
+docker tag $IMAGE_VER $ECR_HOST/$IMAGE_VER
+
+docker push $ECR_HOST/$IMAGE_VER


### PR DESCRIPTION
docker file to build geff as a docker image:

_**Testing**_:
abuse IP DB scan works:
![image](https://user-images.githubusercontent.com/72515998/140196072-38140179-91de-4e68-8518-00458c66674d.png)

ecr list_repos works:
![image](https://user-images.githubusercontent.com/72515998/140196362-6fcabdfc-64f3-4bbc-9047-b592e9be47cc.png)

With storage pipeline works:
![image](https://user-images.githubusercontent.com/72515998/140198977-290733a2-82c9-4bd8-9a97-9453255dd19c.png)