### PR TITLE
Fix destination-uri param, add strftime flags to the path

### DIFF
--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -32,13 +32,9 @@ def parse_destination_uri(destination: Text) -> Tuple[Text, Text]:
     LOG.debug(f'destination from header is {destination}')
     parsed_url = urlparse(destination)
     bucket = parsed_url.netloc
-        
     parts = parsed_url.path.split('/')
-    prefix_parts = [part for part in parts if not part.startswith('%') and part]
-    strftime_parts = [time.strftime(part) for part in parts if part.startswith('%')]
-
-    prefix_with_time = "/".join(prefix_parts + strftime_parts)
-    prefix = prefix_with_time if parsed_url.path.count('/') >= 1 else ''
+    prefix = "/".join([x for x in parts if x]) 
+    prefix = time.strftime(prefix) if parsed_url.path.count('/') >= 1 else ''
     LOG.debug(f'Parsed bucket = {bucket}, prefix = {prefix}.')
     return bucket, prefix
 
@@ -93,7 +89,7 @@ def initialize(destination, batch_id: Text):
     bucket, prefix = parse_destination_uri(destination)
     content = ''  # We use empty body for creating a folder
     if not prefix:
-        prefixed_folder_path = f'{DATA_FOLDER_NAME}/{batch_id}/'
+        prefixed_folder_path = f'{batch_id}/'
     else:
         prefixed_folder_path = f'{prefix}/{batch_id}/'
 
@@ -114,7 +110,7 @@ def write(
     )
 
     if not prefix:
-        prefixed_filename = f'{DATA_FOLDER_NAME}/{batch_id}/row-{row_index}.data.json'
+        prefixed_filename = f'{batch_id}/row-{row_index}.data.json'
     else:
         prefixed_filename = f'{prefix}/{batch_id}/row-{row_index}.data.json'
     s3_uri = f's3://{bucket}/{prefixed_filename}'

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -16,7 +16,6 @@ AWS_REGION = os.environ[
 ]  # Placeholder while in dev TODO: change as variable/header
 S3_CLIENT = boto3.client('s3', region_name=AWS_REGION)
 MANIFEST_FILENAME = 'MANIFEST.json'
-DATA_FOLDER_NAME = 'data'
 MANIESTS_FOLDER_NAME = 'meta'
 
 

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -3,6 +3,7 @@ import os
 from random import sample
 from typing import Any, AnyStr, Dict, Generator, List, Optional, Text, Tuple, Union
 from urllib.parse import urlparse
+import time
 
 import boto3
 from botocore.exceptions import ClientError
@@ -31,7 +32,7 @@ def parse_destination_uri(destination: Text) -> Tuple[Text, Text]:
     LOG.debug(f'destination from header is {destination}')
     parsed_url = urlparse(destination)
     bucket = parsed_url.netloc
-    prefix = parsed_url.path.split('/', 2)[1] if parsed_url.path.count('/') >= 2 else ''
+    prefix = parsed_url.path.strip('/') if parsed_url.path.count('/') >= 1 else ''
     LOG.debug(f'Parsed bucket = {bucket}, prefix = {prefix}.')
     return bucket, prefix
 
@@ -105,11 +106,12 @@ def write(
         if isinstance(datum, list)
         else json.dumps(datum, default=str)
     )
+    date = time.strftime("%Y-%m-%d")
 
     if not prefix:
-        prefixed_filename = f'{DATA_FOLDER_NAME}/{batch_id}/row-{row_index}.data.json'
+        prefixed_filename = f'{DATA_FOLDER_NAME}/{batch_id}/row-{row_index}-{date}.data.json'
     else:
-        prefixed_filename = f'{prefix}/{batch_id}/row-{row_index}.data.json'
+        prefixed_filename = f'{prefix}/{batch_id}/row-{row_index}-{date}.data.json'
     s3_uri = f's3://{bucket}/{prefixed_filename}'
 
     return {

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -112,7 +112,7 @@ def write(
         if isinstance(datum, list)
         else json.dumps(datum, default=str)
     )
-    
+
     if not prefix:
         prefixed_filename = f'{DATA_FOLDER_NAME}/{batch_id}/row-{row_index}.data.json'
     else:

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -88,7 +88,7 @@ def initialize(destination: Text, batch_id: Text):
     content = ''  # We use empty body for creating a folder
     # Regex captures characters after and including the rightmost '/' in a path,
     # which are then replaced with a '/', e.g. '/a/b/c' -> '/a/b/'
-    prefixed_folder_path = re.sub(r'/[^/]*$', "/", prefix)
+    prefixed_folder_path = re.sub(r'/[^/]*$', "/", prefix) if '/' in prefix else ''
 
     if prefixed_folder_path:
         write_to_s3(bucket, prefixed_folder_path, content)

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -88,10 +88,10 @@ def initialize(destination: Text, batch_id: Text):
     content = ''  # We use empty body for creating a folder
     # Regex captures characters after and including the rightmost '/' in a path,
     # which are then replaced with a '/', e.g. '/a/b/c' -> '/a/b/'
-    prefixed_folder_path = re.sub(r'/[^/]*$', "/", prefix) if '/' in prefix else ''
+    prefix_folder = re.sub(r'/[^/]*$', "/", prefix) if '/' in prefix else ''
 
-    if prefixed_folder_path:
-        write_to_s3(bucket, prefixed_folder_path, content)
+    if prefix_folder:
+        write_to_s3(bucket, prefix_folder, content)
 
 
 def write(

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -88,7 +88,7 @@ def initialize(destination: Text, batch_id: Text):
     content = ''  # We use empty body for creating a folder
     # Regex captures characters after and including the rightmost '/' in a path,
     # which are then replaced with a '/', e.g. '/a/b/c' -> '/a/b/'
-    prefix_folder = re.sub(r'/[^/]*$', "/", prefix) if '/' in prefix else ''
+    prefix_folder = re.sub(r'/[^/]*$', '/', prefix) if '/' in prefix else ''
 
     if prefix_folder:
         write_to_s3(bucket, prefix_folder, content)

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -3,7 +3,7 @@ import os
 from random import sample
 from typing import Any, AnyStr, Dict, Generator, List, Optional, Text, Tuple, Union
 from urllib.parse import urlparse
-import time
+from time import strftime
 
 import boto3
 from botocore.exceptions import ClientError
@@ -31,9 +31,9 @@ def parse_destination_uri(destination: Text) -> Tuple[Text, Text]:
     LOG.debug(f'destination from header is {destination}')
     parsed_url = urlparse(destination)
     bucket = parsed_url.netloc
-    parts = parsed_url.path.split('/')
-    prefix = "/".join([x for x in parts if x]) 
-    prefix = time.strftime(prefix) if parsed_url.path.count('/') >= 1 else ''
+    parts = strftime(parsed_url.path).split('/')
+    prefix = "/".join([x for x in parts if x])
+    prefix = prefix if parsed_url.path.count('/') >= 1 else ''
     LOG.debug(f'Parsed bucket = {bucket}, prefix = {prefix}.')
     return bucket, prefix
 

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -4,6 +4,7 @@ from random import sample
 from typing import Any, AnyStr, Dict, Generator, List, Optional, Text, Tuple, Union
 from urllib.parse import urlparse
 from time import strftime
+import re
 
 import boto3
 from botocore.exceptions import ClientError
@@ -85,13 +86,9 @@ def write_to_s3(bucket: Text, filename: Text, content: AnyStr) -> Dict[Text, Any
 def initialize(destination: Text, batch_id: Text):
     bucket, prefix = parse_destination_uri(destination)
     content = ''  # We use empty body for creating a folder
-    prefixed_folder_path = ''
-    if prefix and prefix.count('/') and not prefix.endswith('/'):
-        # Removes characters after the last '/' in a path, since we want to initilaize a folder
-        # E.g. /a/b/c -> /a/b/
-        prefixed_folder_path = '/'.join(prefix.split('/')[:-1]) + '/' 
-    elif prefix.endswith('/'):
-        prefixed_folder_path = prefix
+    # Regex captures characters after and including the rightmost '/' in a path,
+    # which are then replaced with a '/', e.g. '/a/b/c' -> '/a/b/'
+    prefixed_folder_path = re.sub(r'/[^/]*$', "/", prefix)
 
     if prefixed_folder_path:
         write_to_s3(bucket, prefixed_folder_path, content)

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -44,7 +44,7 @@ def async_flow_init(event: Any, context: Any) -> Dict[Text, Any]:
         f'geff.drivers.destination_{urlparse(destination).scheme}'
     )
     # Ignoring style due to dynamic import
-    destination_driver.initialize(destination)  # type: ignore
+    destination_driver.initialize(destination, batch_id)  # type: ignore
 
     LOG.debug('Invoking child lambda.')
     lambda_response = invoke_process_lambda(event, lambda_name)

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -44,7 +44,7 @@ def async_flow_init(event: Any, context: Any) -> Dict[Text, Any]:
         f'geff.drivers.destination_{urlparse(destination).scheme}'
     )
     # Ignoring style due to dynamic import
-    destination_driver.initialize(destination, batch_id)  # type: ignore
+    destination_driver.initialize(destination)  # type: ignore
 
     LOG.debug('Invoking child lambda.')
     lambda_response = invoke_process_lambda(event, lambda_name)


### PR DESCRIPTION
- Fix the prefix path issue and add support for strftime flags in the path. 

- Remove the data folder from the path, that was being added in absence of a prefix.

-------
Bruk had requested if we could support adding timestamps in the path, such that the path would be like `dir/dir/dir/YYYY/MM/DD/` and the files stored would have timestamps too, such as: `row-0-YYYY-MM-DD.json`

Resulting in:
`dir/dir/dir/YYYY/MM/DD/batch-id/row-0-YYYY-MM-DD.json`

-------

Test:

For destination URI: `s3://nachiket-dev-bucket/a/b/c/%Y/%d/%m/alpha/%m/beta/%y_%m_%d/gamma`

<img width="1385" alt="Screenshot 2022-09-15 at 4 59 28 PM" src="https://user-images.githubusercontent.com/77716642/190392647-00b3ba0d-cbfa-44e8-b156-71ad97cf8158.png">

For destination URI: `s3://nachiket-dev-bucket/%m/%d/%Y`

<img width="1400" alt="Screenshot 2022-09-15 at 5 00 44 PM" src="https://user-images.githubusercontent.com/77716642/190392864-c1a43ffe-8496-4319-b91d-2d228282372f.png">

For destination URI: `s3://nachiket-dev-bucket/` (No prefix)

<img width="1352" alt="Screenshot 2022-09-15 at 5 01 40 PM" src="https://user-images.githubusercontent.com/77716642/190393026-e3a0703f-5b22-45e8-b80a-e855637a9dd0.png">

For destination URI: `s3://nachiket-dev-bucket/foobar/` 

<img width="1405" alt="Screenshot 2022-09-15 at 5 02 20 PM" src="https://user-images.githubusercontent.com/77716642/190393140-64168162-4929-4159-82a4-21c04ba10956.png">

For destination URI: `s3://nachiket-dev-bucket/foobar` 

<img width="1366" alt="Screenshot 2022-09-15 at 5 34 21 PM" src="https://user-images.githubusercontent.com/77716642/190399089-f79f68d8-52cf-422b-a851-59fb149058df.png">

