### PR TITLE
Add json body as an auth option

### DIFF
--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -101,7 +101,26 @@ def process_row(
         req_data: Optional[bytes] = (
             json if json.startswith('{') else dumps(parse_header_dict(json))
         ).encode()
+     elif json.startswith('arn'):
+        json if json.startswith('arn') 
+        auth = decrypt_if_encrypted(json)
+        req_auth = (
+        loads(auth)
+        if auth and auth.startswith('{')
+        else parse_header_dict(auth)
+        if auth
+        else {} 
+        ) 
+        auth_host = req_auth.get('host') 
+
+        # We reject the request if the 'auth' is present but doesn't match the pinned host.
+        if auth_host and req_host and auth_host != req_host:
+            raise ValueError(
+                "Requests can only be made to host provided in the auth header."
+            )
         req_headers['Content-Type'] = 'application/json'
+        if('ClientId' and 'secret' in req_auth):
+            req_data={"clientId": str(req_auth['ClientId']),"secret": str(req_auth['secret'])}
     else:
         req_data = None if data is None else data.encode()
 

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -98,29 +98,23 @@ def process_row(
     req_method: str = method.upper()
 
     if json:
+        
         req_data: Optional[bytes] = (
             json if json.startswith('{') else dumps(parse_header_dict(json))
         ).encode()
-     elif json.startswith('arn'):
-        json if json.startswith('arn') 
-        auth = decrypt_if_encrypted(json)
-        req_auth = (
-        loads(auth)
-        if auth and auth.startswith('{')
-        else parse_header_dict(auth)
-        if auth
-        else {} 
-        ) 
-        auth_host = req_auth.get('host') 
-
-        # We reject the request if the 'auth' is present but doesn't match the pinned host.
-        if auth_host and req_host and auth_host != req_host:
-            raise ValueError(
-                "Requests can only be made to host provided in the auth header."
-            )
         req_headers['Content-Type'] = 'application/json'
-        if('ClientId' and 'secret' in req_auth):
-            req_data={"clientId": str(req_auth['ClientId']),"secret": str(req_auth['secret'])}
+        if json.startswith('arn'):
+            data=(decrypt_if_encrypted(json))
+            data=loads(data)
+            json_host=data['host']
+            if json_host and req_host and json_host != req_host:
+                raise ValueError(
+                "Requests can only be made to host provided in the auth header."
+                )
+            if('clientId' and 'secret' in data):
+                LOG.debug('preparing hunters json')
+                payload={"clientId":data['clientId'],"secret":data['secret']}
+                req_data=dumps(payload).encode('utf-8')    
     else:
         req_data = None if data is None else data.encode()
 


### PR DESCRIPTION
Added some changes to the https driver to allow json to be passed for authentication to an api. The code changes have been tested with the amathew-geff-lambda function that is using the geff image with the tag '0.2.0-test'