### PR TITLE
Add json-body option to auth header

### DIFF
--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -29,8 +29,7 @@ def process_row(
     headers: Text = '',
     kwargs: Union[Dict, Text] = '',
     #auth to auth header
-    auth_header: Text = None,
-    auth_body :Optional[Text] = None,
+    auth: Text = None,
     params: Text = '',
     verbose: bool = False,
     cursor: Text = '',
@@ -92,8 +91,8 @@ def process_row(
             req_headers['authorization'] = req_auth['authorization']
         elif 'headers' in req_auth:
             req_headers.update(req_auth['headers'])
-        elif 'clientId' and 'secret' in req_auth:
-            req_headers['Content-Type'] = 'application/json'
+        elif 'body' in req_auth:
+            req_data=req_auth['body']
 
     # query, nextpage_path, results_path
     req_params: str = params
@@ -105,29 +104,6 @@ def process_row(
         req_data: Optional[bytes] = (
             json if json.startswith('{') else dumps(parse_header_dict(json))
         ).encode()
-        if auth_payload:
-            auth = decrypt_if_encrypted(auth_payload)
-            req_auth = (
-                loads(auth)
-                if auth and auth.startswith('{')
-                else parse_header_dict(auth)
-                if auth
-                else {}
-            )
-            auth_host = req_auth.get('host')
-
-            # We reject the request if the 'auth' is present but doesn't match the pinned host.
-            if auth_host and req_host and auth_host != req_host:
-                raise ValueError(
-                    "Requests can only be made to host provided in the auth header."
-                )
-            # If the URL is missing a hostname, use the host from the auth dictionary
-            elif auth_host and not req_host:
-                req_host = auth_host
-            # We make unauthenticated request if the 'host' key is missing.
-            elif not auth_host:
-                raise ValueError(f"'auth' missing the 'host' key.")
-                req_data=dumps(payload).encode('utf-8')
         req_headers['Content-Type'] = 'application/json'
     else:
         req_data = None if data is None else data.encode()

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -109,7 +109,7 @@ def process_row(
     req_method: str = method.upper()
         
     if json:
-        req_data= (
+        req_data: Optional[bytes] = (
             json if json.startswith('{') else dumps(parse_header_dict(json))
         ).encode()
         req_headers['Content-Type'] = 'application/json'

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -98,9 +98,8 @@ def process_row(
                     req_auth['body']
                     if isinstance(req_auth['body'], str)
                     else dumps(req_auth['body'])
-                )    
-                
-        
+                )
+
     # query, nextpage_path, results_path
     req_params: str = params
     req_results_path: str = results_path

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -106,7 +106,7 @@ def process_row(
     req_results_path: str = results_path
     req_cursor: str = cursor
     req_method: str = method.upper()
-        
+ 
     if json:
         req_data: Optional[bytes] = (
             json if json.startswith('{') else dumps(parse_header_dict(json))
@@ -114,7 +114,7 @@ def process_row(
         req_headers['Content-Type'] = 'application/json'
     else:
         req_data = None if data is None else data.encode()
-    
+
     if req_params:
         req_url += f'?{req_params}'
 

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -58,7 +58,7 @@ def process_row(
 
     req_headers.setdefault('User-Agent', 'GEFF 1.0')
     req_headers.setdefault('Accept-Encoding', 'gzip')
-    auth_body: str = None
+    auth_body: Optional[str] = None
 
     # We look for an auth header and if found, we parse it from its encoded format
     if auth:

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -93,7 +93,16 @@ def process_row(
         elif 'headers' in req_auth:
             req_headers.update(req_auth['headers'])
         elif 'body' in req_auth:
-            auth_body = req_auth['body']
+            json_body = (
+                loads(req_auth['body'])
+                if isinstance(req_auth['body'], str)
+                else req_auth['body']
+            )    
+            if json:
+                raise ValueError(f"both auth body and json present")
+            else:
+                json = json_body
+                
         
     # query, nextpage_path, results_path
     req_params: str = params
@@ -101,14 +110,10 @@ def process_row(
     req_cursor: str = cursor
     req_method: str = method.upper()
         
-    if auth_body or json:
-        req_headers['Content-Type'] = 'application/json'
     if json:
         req_data= (
-            json if json.startswith('{') else dumps(parse_header_dict(json.join(auth_body)))
-        ).encode()
-    elif auth_body:
-        req_data = auth_body.encode('utf-8')        
+            json if json.startswith('{') else dumps(parse_header_dict(json))
+        ).encode()       
     else:
         req_data = None if data is None else data.encode()
     

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -106,7 +106,7 @@ def process_row(
     req_results_path: str = results_path
     req_cursor: str = cursor
     req_method: str = method.upper()
- 
+
     if json:
         req_data: Optional[bytes] = (
             json if json.startswith('{') else dumps(parse_header_dict(json))

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -58,7 +58,7 @@ def process_row(
 
     req_headers.setdefault('User-Agent', 'GEFF 1.0')
     req_headers.setdefault('Accept-Encoding', 'gzip')
-    auth_body = None
+    auth_body: str = None
 
     # We look for an auth header and if found, we parse it from its encoded format
     if auth:

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -92,7 +92,7 @@ def process_row(
             req_headers.update(req_auth['headers'])
         elif 'body' in req_auth:   
             if json:
-                raise ValueError(f"both auth body and json present")
+                raise ValueError(f"auth 'body' key and json param are both present")
             else:
                 json = (
                     req_auth['body']

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -54,11 +54,9 @@ def process_row(
             else {}
         ).items()
     }
-    req_data: Optional[bytes]=None
 
     req_headers.setdefault('User-Agent', 'GEFF 1.0')
     req_headers.setdefault('Accept-Encoding', 'gzip')
-    auth_body: Optional[str] = None
 
     # We look for an auth header and if found, we parse it from its encoded format
     if auth:
@@ -94,9 +92,9 @@ def process_row(
             req_headers.update(req_auth['headers'])
         elif 'body' in req_auth:
             json_body = (
-                loads(req_auth['body'])
+                req_auth['body']
                 if isinstance(req_auth['body'], str)
-                else req_auth['body']
+                else dumps(req_auth['body'])
             )    
             if json:
                 raise ValueError(f"both auth body and json present")
@@ -113,7 +111,8 @@ def process_row(
     if json:
         req_data= (
             json if json.startswith('{') else dumps(parse_header_dict(json))
-        ).encode()       
+        ).encode()
+        req_headers['Content-Type'] = 'application/json'
     else:
         req_data = None if data is None else data.encode()
     

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -58,7 +58,7 @@ def process_row(
 
     req_headers.setdefault('User-Agent', 'GEFF 1.0')
     req_headers.setdefault('Accept-Encoding', 'gzip')
-    auth_body = {}
+    auth_body = ''
 
     # We look for an auth header and if found, we parse it from its encoded format
     if auth:
@@ -105,7 +105,7 @@ def process_row(
         req_headers['Content-Type'] = 'application/json'
     if json:
         req_data= (
-            json if json.startswith('{') else dumps(parse_header_dict(json.update(auth_body)))
+            json if json.startswith('{') else dumps(parse_header_dict(json+=auth_body))
         ).encode()
     elif auth_body:
         req_data = auth_body.encode('utf-8')        

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -104,7 +104,6 @@ def process_row(
             json if json.startswith('{') else dumps(parse_header_dict(json))
         ).encode()
         if('Content-Type' in req_headers):
-            #remove the host part
             payload={"clientId":req_auth['clientId'],"secret":req_auth['secret']}
             req_data=dumps(payload).encode('utf-8')
         req_headers['Content-Type'] = 'application/json'

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -93,8 +93,8 @@ def process_row(
         elif 'headers' in req_auth:
             req_headers.update(req_auth['headers'])
         elif 'body' in req_auth:
-            pre_data=req_auth['body']
-            req_data1=pre_data.encode('utf-8')
+            pre_data = req_auth['body']
+            req_data = pre_data.encode('utf-8')
         
     # query, nextpage_path, results_path
     req_params: str = params

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -105,7 +105,7 @@ def process_row(
         req_headers['Content-Type'] = 'application/json'
     if json:
         req_data= (
-            json if json.startswith('{') else dumps(parse_header_dict(json+=auth_body))
+            json if json.startswith('{') else dumps(parse_header_dict(json.join(auth_body)))
         ).encode()
     elif auth_body:
         req_data = auth_body.encode('utf-8')        

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -93,8 +93,8 @@ def process_row(
         elif 'headers' in req_auth:
             req_headers.update(req_auth['headers'])
         elif 'body' in req_auth:
-            req_data=req_auth['body']
-            req_data=req_data.encode('utf-8')
+            pre_data=req_auth['body']
+            req_data1=pre_data.encode('utf-8')
         
     # query, nextpage_path, results_path
     req_params: str = params
@@ -103,7 +103,7 @@ def process_row(
     req_method: str = method.upper()
 
     if json:
-        req_data: Optional[bytes] = (
+        req_data= (
             json if json.startswith('{') else dumps(parse_header_dict(json))
         ).encode()
         req_headers['Content-Type'] = 'application/json'

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -101,6 +101,19 @@ def process_row(
         req_data: Optional[bytes] = (
             json if json.startswith('{') else dumps(parse_header_dict(json))
         ).encode()
+        if json.startswith('arn'):
+            data=(decrypt_if_encrypted(json))
+            data=loads(data)
+            #remove the host part
+            json_host=data['host']
+            if json_host and req_host and json_host != req_host:
+                raise ValueError(
+                "Requests can only be made to host provided in the auth header."
+                )
+            if('clientId' and 'secret' in data):
+                LOG.debug('preparing hunters json')
+                payload={"clientId":data['clientId'],"secret":data['secret']}
+                req_data=dumps(payload).encode('utf-8')
         req_headers['Content-Type'] = 'application/json'
     else:
         req_data = None if data is None else data.encode()

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -55,6 +55,7 @@ def process_row(
             else {}
         ).items()
     }
+    req_data: Optional[bytes]=None
 
     req_headers.setdefault('User-Agent', 'GEFF 1.0')
     req_headers.setdefault('Accept-Encoding', 'gzip')

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -93,7 +93,8 @@ def process_row(
             req_headers.update(req_auth['headers'])
         elif 'body' in req_auth:
             req_data=req_auth['body']
-
+            req_data=req_data.encode('utf-8')
+        
     # query, nextpage_path, results_path
     req_params: str = params
     req_results_path: str = results_path

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -90,16 +90,15 @@ def process_row(
             req_headers['authorization'] = req_auth['authorization']
         elif 'headers' in req_auth:
             req_headers.update(req_auth['headers'])
-        elif 'body' in req_auth:
-            json_body = (
-                req_auth['body']
-                if isinstance(req_auth['body'], str)
-                else dumps(req_auth['body'])
-            )    
+        elif 'body' in req_auth:   
             if json:
                 raise ValueError(f"both auth body and json present")
             else:
-                json = json_body
+                json = (
+                    req_auth['body']
+                    if isinstance(req_auth['body'], str)
+                    else dumps(req_auth['body'])
+                )    
                 
         
     # query, nextpage_path, results_path

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -58,7 +58,7 @@ def process_row(
 
     req_headers.setdefault('User-Agent', 'GEFF 1.0')
     req_headers.setdefault('Accept-Encoding', 'gzip')
-    auth_body = ''
+    auth_body = None
 
     # We look for an auth header and if found, we parse it from its encoded format
     if auth:

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -104,8 +104,9 @@ def process_row(
             json if json.startswith('{') else dumps(parse_header_dict(json))
         ).encode()
         if('Content-Type' in req_headers):
-            payload={"clientId":req_auth['clientId'],"secret":req_auth['secret']}
-            req_data=dumps(payload).encode('utf-8')
+            if auth:
+                payload={"clientId":req_auth['clientId'],"secret":req_auth['secret']}
+                req_data=dumps(payload).encode('utf-8')
         req_headers['Content-Type'] = 'application/json'
     else:
         req_data = None if data is None else data.encode()


### PR DESCRIPTION
Certain API require credentials to be passed part of the payload as opposed to headers that GEFF currently supports. This PR is to allow users to provide credentials to GEFF via payload. 

This change has been tested using an API that requires a payload in the body to authenticate. 