### PR TITLE
Add type check for cursor_value

### DIFF
--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -195,7 +195,7 @@ def process_row(
 
             next_url = (
                 cursor_value
-                if cursor_value and cursor_value.startswith('https://')
+                if cursor_value and isinstance(cursor_value, str) and cursor_value.startswith('https://')
                 else f'{req_url}&{cursor_param}={cursor_value}'
                 if cursor_value
                 else None


### PR DESCRIPTION
This PR fixes the error occurring due to a type mismatch in the conditional modified, when pagination is used. 

Instead of an integer, a string is expected in the particular conditional.
   
 The error message:
 
 
 ```
    "error": "AttributeError(\"'int' object has no attribute 'startswith'\")",
    "trace": "[8] ./../runtime/bootstrap.py:60 in <module>\n    main()\n./../runtime/bootstrap.py:57 in main\n    awslambdaricmain.main([os.environ[\"LAMBDA_TASK_ROOT\"], os.environ[\"_HANDLER\"]])\n./../runtime/awslambdaric/__main__.py:21 in main\n    bootstrap.run(app_root, handler, lambda_runtime_api_addr)\n./../runtime/awslambdaric/bootstrap.py:405 in run\n    handle_event_request(\n./../runtime/awslambdaric/bootstrap.py:149 in handle_event_request\n    response = request_handler(event, lambda_context)\n./geff/lambda_function.py:209 in lambda_handler\n    return sync_flow(event, context)\n./geff/lambda_function.py:138 in sync_flow\n    row_result = [{'error': repr(e), 'trace': format_trace(e)}]\n--- printed exception w/ trace ---\n./geff/lambda_function.py:128 in sync_flow\n    row_result = process_row(*path, **process_row_params)\n./geff/drivers/process_https.py:206 in process_row\n    if cursor_value and cursor_value.startswith('https://')\nAttributeError: 'int' object has no attribute 'startswith'"
 
```