### PR TITLE
Fix lambda response length check on dict

### DIFF
--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -159,22 +159,25 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
         }
 
     if len(dumps(response)) > 6_000_000:
-        response = dumps(
-            {
-                'data': [
-                    [
-                        rn,
-                        {
-                            'error': (
-                                f'Response size ({len(dumps(response))} bytes) will likely'
-                                'exceeded maximum allowed payload size (6291556 bytes).'
-                            )
-                        },
+        response = {
+            'statusCode': 202,
+            'body': dumps(
+                {
+                    'data': [
+                        [
+                            rn,
+                            {
+                                'error': (
+                                    f'Response size ({len(dumps(response))} bytes) will likely '
+                                    'exceeded maximum allowed payload size (6291556 bytes).'
+                                )
+                            },
+                        ]
+                        for rn, *args in req_body['data']
                     ]
-                    for rn, *args in req_body['data']
-                ]
-            }
-        )
+                }
+            ),
+        }
     return response
 
 

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -155,10 +155,10 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
             'statusCode': 200,
             'body': b64encode(compress(data_dumps.encode())).decode(),
             'isBase64Encoded': True,
-            'headers': {'Content-Encoding': 'gzip'}
+            'headers': {'Content-Encoding': 'gzip'},
         }
 
-    if len(response) > 6_000_000:
+    if len(dumps(response)) > 6_000_000:
         response = dumps(
             {
                 'data': [
@@ -166,7 +166,7 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
                         rn,
                         {
                             'error': (
-                                f'Response size ({len(response)} bytes) will likely'
+                                f'Response size ({len(dumps(response))} bytes) will likely'
                                 'exceeded maximum allowed payload size (6291556 bytes).'
                             )
                         },

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -158,7 +158,7 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
             'headers': {'Content-Encoding': 'gzip'},
         }
 
-    if len(dumps(response)) > 6_000_000:
+    if len(dumps(response)) > 6_291_556:
         response = {
             'statusCode': 200,
             'body': dumps(
@@ -168,7 +168,7 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
                             rn,
                             {
                                 'error': (
-                                    f'Response size ({len(dumps(response))} bytes) will likely '
+                                    f'Response size ({len(dumps(response))} bytes) will '
                                     'exceeded maximum allowed payload size (6291556 bytes).'
                                 )
                             },

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -157,8 +157,9 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
             'isBase64Encoded': True,
             'headers': {'Content-Encoding': 'gzip'},
         }
+    response_length = len(dumps(response))
 
-    if len(dumps(response)) > 6_291_556:
+    if response_length > 6_291_556:
         response = {
             'statusCode': 200,
             'body': dumps(
@@ -168,7 +169,7 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
                             rn,
                             {
                                 'error': (
-                                    f'Response size ({len(dumps(response))} bytes) '
+                                    f'Response size ({response_length} bytes) '
                                     'exceeded maximum allowed payload size (6291556 bytes).'
                                 )
                             },

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -160,7 +160,7 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
 
     if len(dumps(response)) > 6_000_000:
         response = {
-            'statusCode': 202,
+            'statusCode': 200,
             'body': dumps(
                 {
                     'data': [

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -157,8 +157,8 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
             'isBase64Encoded': True,
             'headers': {'Content-Encoding': 'gzip'},
         }
-    response_length = len(dumps(response))
 
+    response_length = len(dumps(response))
     if response_length > 6_291_556:
         response = {
             'statusCode': 200,

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -168,7 +168,7 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
                             rn,
                             {
                                 'error': (
-                                    f'Response size ({len(dumps(response))} bytes) will '
+                                    f'Response size ({len(dumps(response))} bytes) '
                                     'exceeded maximum allowed payload size (6291556 bytes).'
                                 )
                             },


### PR DESCRIPTION
This PR fixes the response to be returned when the API response size exceeds Lambda's limits. 

Testing: 

Constructed a response of ~11 MB after compression, the output in Snowflake:

![Screenshot 2023-01-06 at 6 00 43 PM](https://user-images.githubusercontent.com/77716642/211013069-57956d6a-6ea1-4919-a40c-a32ded408358.png)
