### PR TITLE
Add support for storing non-json responses, and a hashsum flag in paths

### DIFF
--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -5,6 +5,7 @@ from typing import Any, AnyStr, Dict, Generator, List, Optional, Text, Tuple, Un
 from urllib.parse import urlparse
 from time import strftime
 import re
+from hashlib import md5, sha3_256
 
 import boto3
 from botocore.exceptions import ClientError
@@ -31,10 +32,7 @@ def parse_destination_uri(destination: Text) -> Tuple[Text, Text]:
     """
     LOG.debug(f'destination from header is {destination}')
     parsed_url = urlparse(destination)
-    return (
-        parsed_url.netloc,
-        strftime(parsed_url.path[1:])  # remove leading slash
-    )
+    return (parsed_url.netloc, strftime(parsed_url.path[1:]))  # remove leading slash
 
 
 def estimated_record_size(records: List[Dict[Text, Any]]) -> float:
@@ -116,6 +114,8 @@ def write(
             prefixed_filename,
             encoded_datum,
         ),
+        'md5_hash': md5(encoded_datum.encode('utf-8')).hexdigest(),
+        'sha3_hash': sha3_256(encoded_datum.encode('utf-8')).hexdigest(),
         'uri': s3_uri,
     }
 

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -105,7 +105,7 @@ def write(
         prefixed_filename = prefix.format(hash=encoded_datum_hash)
     else:
         encoded_datum = (
-            '\n'.join(json.dumps(d) for d in datum)
+            '\n'.join(json.dumps(d) for d in datum)  # type: ignore
             if isinstance(datum, list)
             else json.dumps(datum, default=str)
         )

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -104,7 +104,6 @@ def write(
         prefixed_filename = hash_format(
             prefix, encoded_datum, sha3_256=lambda x: sha3_256(x).hexdigest()
         )
-        LOG.debug(f"hash: {sha3_256(encoded_datum).hexdigest()}")
     else:
         encoded_datum = (
             '\n'.join(json.dumps(d) for d in datum)

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -89,7 +89,7 @@ def initialize(destination: Text, batch_id: Text):
     # which are then replaced with a '/', e.g. '/a/b/c' -> '/a/b/'
     prefix_folder = re.sub(r'/[^/]*$', '/', prefix) if '/' in prefix else ''
     prefix_folder = (
-        re.sub(r'/{\s*sha2\s*}/$', '/', prefix_folder, flags=re.IGNORECASE)
+        re.sub(r'/{\s*sha2\s*}.*', '/', prefix_folder, flags=re.IGNORECASE)
         if HASH_PARAM in prefix_folder.lower()
         else prefix_folder
     )

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -19,6 +19,7 @@ AWS_REGION = os.environ[
 S3_CLIENT = boto3.client('s3', region_name=AWS_REGION)
 MANIFEST_FILENAME = 'MANIFEST.json'
 MANIESTS_FOLDER_NAME = 'meta'
+HASH_PARAM = 'hash'
 
 
 def parse_destination_uri(destination: Text) -> Tuple[Text, Text]:
@@ -87,8 +88,12 @@ def initialize(destination: Text, batch_id: Text):
     # Regex captures characters after and including the rightmost '/' in a path,
     # which are then replaced with a '/', e.g. '/a/b/c' -> '/a/b/'
     prefix_folder = re.sub(r'/[^/]*$', '/', prefix) if '/' in prefix else ''
-    prefix_folder = re.sub(r'/{\s*hash\s*}.*', '/', prefix_folder, flags=re.IGNORECASE)
-
+    prefix_folder = re.sub(
+        r'/{\s*' + HASH_PARAM + r'\s*}.*',
+        '/',
+        prefix_folder,
+        flags=re.IGNORECASE,
+    )
     if prefix_folder:
         write_to_s3(bucket, prefix_folder, content)
 

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -107,6 +107,7 @@ def write(
         else json.dumps(datum, default=str).encode()
     )
     encoded_datum_hash = sha256(encoded_datum).hexdigest()
+
     prefixed_filename = (
         f'{prefix}{batch_id}_row_{row_index}.data.json'
         if prefix.endswith('/')

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -1,7 +1,7 @@
 import json
 import os
 from random import sample
-from typing import Any, Dict, Generator, List, Optional, Text, Tuple, Union, AnyStr
+from typing import Any, AnyStr, Dict, Generator, List, Optional, Text, Tuple, Union
 from urllib.parse import urlparse
 from time import strftime
 import re

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -19,7 +19,6 @@ AWS_REGION = os.environ[
 S3_CLIENT = boto3.client('s3', region_name=AWS_REGION)
 MANIFEST_FILENAME = 'MANIFEST.json'
 MANIESTS_FOLDER_NAME = 'meta'
-HASH_PARAM = 'sha2'
 
 
 def parse_destination_uri(destination: Text) -> Tuple[Text, Text]:
@@ -88,11 +87,7 @@ def initialize(destination: Text, batch_id: Text):
     # Regex captures characters after and including the rightmost '/' in a path,
     # which are then replaced with a '/', e.g. '/a/b/c' -> '/a/b/'
     prefix_folder = re.sub(r'/[^/]*$', '/', prefix) if '/' in prefix else ''
-    prefix_folder = (
-        re.sub(r'/{\s*sha2\s*}.*', '/', prefix_folder, flags=re.IGNORECASE)
-        if HASH_PARAM in prefix_folder.lower()
-        else prefix_folder
-    )
+    prefix_folder = re.sub(r'/{\s*sha2\s*}.*', '/', prefix_folder, flags=re.IGNORECASE)
 
     if prefix_folder:
         write_to_s3(bucket, prefix_folder, content)

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -88,12 +88,7 @@ def initialize(destination: Text, batch_id: Text):
     # Regex captures characters after and including the rightmost '/' in a path,
     # which are then replaced with a '/', e.g. '/a/b/c' -> '/a/b/'
     prefix_folder = re.sub(r'/[^/]*$', '/', prefix) if '/' in prefix else ''
-    prefix_folder = re.sub(
-        r'/{\s*' + HASH_PARAM + r'\s*}.*',
-        '/',
-        prefix_folder,
-        flags=re.IGNORECASE,
-    )
+    prefix_folder = re.sub(r'/{[^}].*', '/', prefix_folder)
     if prefix_folder:
         write_to_s3(bucket, prefix_folder, content)
 

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -1,7 +1,7 @@
 import json
 import os
 from random import sample
-from typing import Any, Dict, Generator, List, Optional, Text, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Text, Tuple, Union, AnyStr
 from urllib.parse import urlparse
 from time import strftime
 import re
@@ -73,7 +73,7 @@ def chunker(records: List[Any], chunk_size: int) -> Generator[List[Any], None, N
         yield records[pos : pos + chunk_size]
 
 
-def write_to_s3(bucket: Text, filename: Text, content: bytes) -> Dict[Text, Any]:
+def write_to_s3(bucket: Text, filename: Text, content: AnyStr) -> Dict[Text, Any]:
     return S3_CLIENT.put_object(
         Bucket=bucket,
         Body=content,
@@ -99,12 +99,12 @@ def write(
     row_index: int,
 ) -> Dict[Text, Any]:
     bucket, prefix = parse_destination_uri(destination)
-    encoded_datum = bytes(
+    encoded_datum = (
         datum
         if isinstance(datum, bytes)
-        else '\n'.join(json.dumps(d) for d in datum)
+        else ('\n'.join(json.dumps(d) for d in datum)).encode()
         if isinstance(datum, list)
-        else json.dumps(datum, default=str)
+        else json.dumps(datum, default=str).encode()
     )
     encoded_datum_hash = sha256(encoded_datum).hexdigest()
     prefixed_filename = (

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -114,8 +114,8 @@ def write(
             prefixed_filename,
             encoded_datum,
         ),
-        'md5_hash': md5(encoded_datum.encode('utf-8')).hexdigest(),
-        'sha3_hash': sha3_256(encoded_datum.encode('utf-8')).hexdigest(),
+        'response_md5_hash': md5(encoded_datum.encode('utf-8')).hexdigest(),
+        'response_sha3_hash': sha3_256(encoded_datum.encode('utf-8')).hexdigest(),
         'uri': s3_uri,
     }
 

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -19,7 +19,6 @@ AWS_REGION = os.environ[
 S3_CLIENT = boto3.client('s3', region_name=AWS_REGION)
 MANIFEST_FILENAME = 'MANIFEST.json'
 MANIESTS_FOLDER_NAME = 'meta'
-HASH_PARAM = 'hash'
 
 
 def parse_destination_uri(destination: Text) -> Tuple[Text, Text]:

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -102,7 +102,9 @@ def write(
     bucket, prefix = parse_destination_uri(destination)
     if isinstance(datum, bytes):
         encoded_datum = datum
-        prefixed_filename = prefix
+        prefixed_filename = hash_format(
+            prefix, encoded_datum, sha2=lambda x: sha256(x).hexdigest()
+        )
     else:
         encoded_datum = (
             '\n'.join(json.dumps(d) for d in datum)
@@ -111,9 +113,6 @@ def write(
         )
         prefixed_filename = f'{prefix}{batch_id}_row_{row_index}.data.json'
 
-    prefixed_filename = hash_format(
-        prefixed_filename, encoded_datum, sha2=lambda x: sha256(x).hexdigest()
-    )
     s3_uri = f's3://{bucket}/{prefixed_filename}'
 
     return {

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -102,9 +102,7 @@ def write(
     bucket, prefix = parse_destination_uri(destination)
     if isinstance(datum, bytes):
         encoded_datum = datum
-        prefixed_filename = hash_format(
-            prefix, encoded_datum, sha2=lambda x: sha256(x).hexdigest()
-        )
+        prefixed_filename = prefix
     else:
         encoded_datum = (
             '\n'.join(json.dumps(d) for d in datum)
@@ -113,6 +111,9 @@ def write(
         )
         prefixed_filename = f'{prefix}{batch_id}_row_{row_index}.data.json'
 
+    prefixed_filename = hash_format(
+        prefixed_filename, encoded_datum, sha2=lambda x: sha256(x).hexdigest()
+    )
     s3_uri = f's3://{bucket}/{prefixed_filename}'
 
     return {

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -19,7 +19,7 @@ AWS_REGION = os.environ[
 S3_CLIENT = boto3.client('s3', region_name=AWS_REGION)
 MANIFEST_FILENAME = 'MANIFEST.json'
 MANIESTS_FOLDER_NAME = 'meta'
-HASH_PARAM = '{sha2}'
+HASH_PARAM = 'sha2'
 
 
 def parse_destination_uri(destination: Text) -> Tuple[Text, Text]:
@@ -89,7 +89,7 @@ def initialize(destination: Text, batch_id: Text):
     # which are then replaced with a '/', e.g. '/a/b/c' -> '/a/b/'
     prefix_folder = re.sub(r'/[^/]*$', '/', prefix) if '/' in prefix else ''
     prefix_folder = (
-        re.sub(r'/{\s*sha2\s*}/$', '/', prefix, flags=re.IGNORECASE)
+        re.sub(r'/{\s*sha2\s*}/$', '/', prefix_folder, flags=re.IGNORECASE)
         if HASH_PARAM in prefix_folder.lower()
         else prefix_folder
     )

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -119,17 +119,15 @@ def write(
 
     s3_uri = f's3://{bucket}/{prefixed_filename}'
 
-    response = {
+    return {
         'response': write_to_s3(
             bucket,
             prefixed_filename,
             encoded_datum,
         ),
         'uri': s3_uri,
+        'sha256': encoded_datum_hash,
     }
-    if isinstance(encoded_datum, bytes):
-        response['sha256'] = encoded_datum_hash
-    return response
 
 
 def finalize(

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -9,7 +9,7 @@ from hashlib import sha256
 
 import boto3
 from botocore.exceptions import ClientError
-from ..utils import LOG, lazy_format
+from ..utils import LOG
 
 SAMPLE_SIZE: int = 10
 MAX_JSON_FILE_SIZE: int = 15 * 1024 * 1024 * 1024
@@ -95,14 +95,14 @@ def initialize(destination: Text, batch_id: Text):
 def write(
     destination: Text,
     batch_id: Text,
-    datum: Union[Dict, List],
+    datum: Union[Dict, List, bytes],
     row_index: int,
 ) -> Dict[Text, Any]:
     bucket, prefix = parse_destination_uri(destination)
     if isinstance(datum, bytes):
         encoded_datum = datum
         encoded_datum_hash = sha256(encoded_datum).hexdigest()
-        prefixed_filename = lazy_format(prefix, hash=lambda: encoded_datum_hash)
+        prefixed_filename = prefix.format(hash=encoded_datum_hash)
     else:
         encoded_datum = (
             '\n'.join(json.dumps(d) for d in datum)
@@ -122,7 +122,7 @@ def write(
         'uri': s3_uri,
     }
     if isinstance(encoded_datum, bytes):
-        response['sha256_hash'] = encoded_datum_hash
+        response['sha256'] = encoded_datum_hash
     return response
 
 

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -101,9 +101,8 @@ def write(
     bucket, prefix = parse_destination_uri(destination)
     if isinstance(datum, bytes):
         encoded_datum = datum
-        prefixed_filename = lazy_format(
-            prefix, hash=lambda: sha256(encoded_datum).hexdigest()
-        )
+        encoded_datum_hash = sha256(encoded_datum).hexdigest()
+        prefixed_filename = lazy_format(prefix, hash=lambda: encoded_datum_hash)
     else:
         encoded_datum = (
             '\n'.join(json.dumps(d) for d in datum)
@@ -123,7 +122,7 @@ def write(
         'uri': s3_uri,
     }
     if isinstance(encoded_datum, bytes):
-        response['sha256_hash'] = sha256(encoded_datum).hexdigest()
+        response['sha256_hash'] = encoded_datum_hash
     return response
 
 

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -143,12 +143,13 @@ def process_row(
                 if 'Date' in response_headers
                 else None
             )
-            try:
-                response_body = loads(raw_response)
-            except UnicodeDecodeError:
-                response_body = BytesIO(raw_response).getbuffer().tobytes()
-            LOG.debug('Extracted data from response.')
 
+            if response_headers['Content-Type'] == 'application/json':
+                response_body = loads(raw_response)
+            else:
+                response_body = BytesIO(raw_response).getbuffer().tobytes()
+
+            LOG.debug('Extracted data from response.')
             response = (
                 {
                     'body': response_body,

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -33,7 +33,6 @@ def process_row(
     verbose: bool = False,
     cursor: Text = '',
     results_path: Text = '',
-    write_uri: Optional[Text] = '',
 ):
     if not base_url and not url:
         raise ValueError('Missing required parameter. Need one of url or base-url.')

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Text, Union
 from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qsl, urlparse
 from urllib.request import Request, urlopen
+from io import BytesIO
 
 from ..utils import LOG, parse_header_links, pick
 from ..vault import decrypt_if_encrypted
@@ -32,6 +33,7 @@ def process_row(
     verbose: bool = False,
     cursor: Text = '',
     results_path: Text = '',
+    write_uri: Optional[Text] = '',
 ):
     if not base_url and not url:
         raise ValueError('Missing required parameter. Need one of url or base-url.')
@@ -141,7 +143,10 @@ def process_row(
                 if 'Date' in response_headers
                 else None
             )
-            response_body = loads(raw_response)
+            try:
+                response_body = loads(raw_response)
+            except UnicodeDecodeError:
+                response_body = BytesIO(raw_response).getbuffer().tobytes()
             LOG.debug('Extracted data from response.')
 
             response = (

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -142,12 +142,11 @@ def process_row(
                 if 'Date' in response_headers
                 else None
             )
-
-            if response_headers['Content-Type'] == 'application/json':
-                response_body = loads(raw_response)
-            else:
-                response_body = BytesIO(raw_response).getbuffer().tobytes()
-
+            response_body = (
+                loads(raw_response)
+                if response_headers['Content-Type'] == 'application/json'
+                else BytesIO(raw_response).getbuffer().tobytes()
+            )
             LOG.debug('Extracted data from response.')
 
             response = (

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -149,6 +149,7 @@ def process_row(
                 response_body = BytesIO(raw_response).getbuffer().tobytes()
 
             LOG.debug('Extracted data from response.')
+
             response = (
                 {
                     'body': response_body,

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -14,7 +14,6 @@ from .utils import (
     create_response,
     format,
     invoke_process_lambda,
-    process_row_params_format,
 )
 
 # pip install --target ./site-packages -r requirements.txt
@@ -23,6 +22,18 @@ sys.path.append(os.path.join(dir_path, 'site-packages'))
 
 BATCH_ID_HEADER = 'sf-external-function-query-batch-id'
 DESTINATION_URI_HEADER = 'sf-custom-destination-uri'
+
+
+def process_row_params_format(headers, args):
+    '''
+    Format row parameters
+    '''
+
+    return {
+        k.replace('sf-custom-', '').replace('-', '_'): format(v, args)
+        for k, v in headers.items()
+        if k.startswith('sf-custom-')
+    }
 
 
 def async_flow_init(event: Any, context: Any) -> Dict[Text, Any]:

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -5,7 +5,7 @@ from base64 import b64encode
 from gzip import compress
 from importlib import import_module
 from json import dumps, loads
-from typing import Any, Dict, Text
+from typing import Any, Dict, Text, Tuple
 from urllib.parse import urlparse
 
 from .log import format_trace
@@ -24,9 +24,18 @@ BATCH_ID_HEADER = 'sf-external-function-query-batch-id'
 DESTINATION_URI_HEADER = 'sf-custom-destination-uri'
 
 
-def process_row_params_format(headers, args):
+def process_row_params_format(
+    headers: Dict[Text, Text], args: Tuple[Any]
+) -> Dict[Text, Any]:
     '''
-    Format row parameters
+    Format parameters in headers with arguments from a row.
+
+    Args:
+        headers (Dict[Text, Text]): Headers obtained from the event.
+        args (Tuple[Any]): Arguments obtained from the request body.
+
+    Returns:
+        Dict[Text, Any]: Returns formatted
     '''
 
     return {

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -132,10 +132,9 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
             LOG.debug(f'Got row_result for URL: {process_row_params.get("url")}.')
 
             if write_uri:
-                parameterized_write_uri = format(write_uri, args)
                 # Write s3 data and return confirmation
-                row_result = destination_driver.write(  # type: ignore
-                    parameterized_write_uri, batch_id, row_result, row_number
+                row_result = destination_driver.write(
+                    format(write_uri, args), batch_id, row_result, row_number
                 )
 
         except Exception as e:

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -133,7 +133,7 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
 
             if write_uri:
                 # Write s3 data and return confirmation
-                row_result = destination_driver.write(
+                row_result = destination_driver.write(  # type: ignore
                     format(write_uri, args), batch_id, row_result, row_number
                 )
 

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -120,7 +120,7 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
     for row_number, *args in req_body['data']:
         row_result = []
         process_row_params = process_row_params_format(headers, args)
-        write_uri = process_row_params['write_uri']
+        write_uri = process_row_params.get('write_uri')
 
         try:
             driver, *path = event['path'].lstrip('/').split('/')

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -118,7 +118,6 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
             for k, v in headers.items()
             if k.startswith('sf-custom-')
         }
-        parameterized_write_uri = format(write_uri, args)
 
         try:
             driver, *path = event['path'].lstrip('/').split('/')
@@ -132,7 +131,8 @@ def sync_flow(event: Any, context: Any = None) -> Dict[Text, Any]:
             row_result = process_row(*path, **process_row_params)
             LOG.debug(f'Got row_result for URL: {process_row_params.get("url")}.')
 
-            if parameterized_write_uri:
+            if write_uri:
+                parameterized_write_uri = format(write_uri, args)
                 # Write s3 data and return confirmation
                 row_result = destination_driver.write(  # type: ignore
                     parameterized_write_uri, batch_id, row_result, row_number

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -46,7 +46,7 @@ def async_flow_init(event: Any, context: Any) -> Dict[Text, Any]:
     destination_driver = import_module(
         f'geff.drivers.destination_{urlparse(destination).scheme}'
     )
-    # Ignoring style due to dynamic imports
+    # Ignoring style due to dynamic import
     destination_driver.initialize(destination, batch_id)  # type: ignore
 
     LOG.debug('Invoking child lambda.')

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -5,7 +5,7 @@ import re
 import sys
 from codecs import encode
 from json import dumps
-from typing import Any, Dict, Optional, Text, Callable
+from typing import Any, Dict, Optional, Text
 
 import boto3
 

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -107,3 +107,29 @@ def invoke_process_lambda(event: Any, lambda_name: Text) -> Dict[Text, Any]:
 
     # Returns 202 on success if InvocationType = 'Event'
     return lambda_response
+
+
+def hash_format(fmt_str, datum, **kwargs):
+    '''
+    Format filepath with the hashsum of a datum
+    '''
+
+    def lazy_eval(match_obj):
+        key = match_obj.group(1)
+        if key in kwargs:
+            return str(kwargs[key](datum))
+        return match_obj.group(0)
+
+    return re.sub(r'\{(\w+)\}', lazy_eval, fmt_str)
+
+
+def process_row_params_format(headers, args):
+    '''
+    Format row parameters
+    '''
+
+    return {
+        k.replace('sf-custom-', '').replace('-', '_'): format(v, args)
+        for k, v in headers.items()
+        if k.startswith('sf-custom-')
+    }

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -5,7 +5,7 @@ import re
 import sys
 from codecs import encode
 from json import dumps
-from typing import Any, Dict, Optional, Text
+from typing import Any, Dict, Optional, Text, Callable
 
 import boto3
 
@@ -109,13 +109,13 @@ def invoke_process_lambda(event: Any, lambda_name: Text) -> Dict[Text, Any]:
     return lambda_response
 
 
-def lazy_format(s: str, **kwargs):
+def lazy_format(s: str, **kwargs: Callable[[], str]) -> str:
     '''
     Lazily formats a string by calling the replacement values and using their result
 
     Args:
     s (str): String to be formatted
-    **kwargs (dict[str]() -> str): Maps replacement fields to formatting functions
+    **kwargs (Callable[[], str]): Maps replacement fields to formatting functions
 
     Returns:
     str: Formatted string

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -109,27 +109,22 @@ def invoke_process_lambda(event: Any, lambda_name: Text) -> Dict[Text, Any]:
     return lambda_response
 
 
-def hash_format(fmt_str, datum, **kwargs):
+def lazy_format(s: str, **kwargs):
     '''
-    Format filepath with the hashsum of a datum
+    Lazily formats a string by calling the replacement values and using their result
+
+    Args:
+    s (str): String to be formatted
+    **kwargs (dict[str]() -> str): Maps replacement fields to formatting functions
+
+    Returns:
+    str: Formatted string
     '''
 
     def lazy_eval(match_obj):
         key = match_obj.group(1)
         if key in kwargs:
-            return str(kwargs[key](datum))
+            return str(kwargs[key]())
         return match_obj.group(0)
 
-    return re.sub(r'\{(\w+)\}', lazy_eval, fmt_str)
-
-
-def process_row_params_format(headers, args):
-    '''
-    Format row parameters
-    '''
-
-    return {
-        k.replace('sf-custom-', '').replace('-', '_'): format(v, args)
-        for k, v in headers.items()
-        if k.startswith('sf-custom-')
-    }
+    return re.sub(r'\{(\w+)\}', lazy_eval, s)

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -107,24 +107,3 @@ def invoke_process_lambda(event: Any, lambda_name: Text) -> Dict[Text, Any]:
 
     # Returns 202 on success if InvocationType = 'Event'
     return lambda_response
-
-
-def lazy_format(s: str, **kwargs: Callable[[], str]) -> str:
-    '''
-    Lazily formats a string by calling the replacement values and using their result
-
-    Args:
-    s (str): String to be formatted
-    **kwargs (Callable[[], str]): Maps replacement fields to formatting functions
-
-    Returns:
-    str: Formatted string
-    '''
-
-    def lazy_eval(match_obj):
-        key = match_obj.group(1)
-        if key in kwargs:
-            return str(kwargs[key]())
-        return match_obj.group(0)
-
-    return re.sub(r'\{(\w+)\}', lazy_eval, s)


### PR DESCRIPTION
This PR adds support for the storage of non-json/file responses to S3 and storing their sha256 hashsum in the file paths, thorugh a flag.

The hashum flag can be added like: `s3://geff-bucket/foo/{sha2}/bar`, which then gets replaced by the hash of the response: `s3://geff-bucket/foo/d5e2f10fe2e5d7ed2001c5513c22c56330519342e76f6467919310497d5c5ce6/bar`

Testing:

Example flow for driver storage:

Getting file names and links:

![Screenshot 2023-02-15 at 12 47 50 PM](https://user-images.githubusercontent.com/77716642/218960683-cc3b1516-bc28-43e1-bcd1-54695f25f8cd.png)

External function:
```
CREATE OR REPLACE SECURE EXTERNAL FUNCTION TEST_FUNCTION(url string, destination string)
RETURNS VARIANT
RETURNS NULL ON NULL INPUT
VOLATILE
API_INTEGRATION= API_INTEGRATION
HEADERS=(
   'url'     = '{0}'
   'headers' = '{"Content-Type": "application/json", "Accept": "application/json"}'
   'method'  = 'GET'
   'destination-uri' = 's3://geff-rlm-dev-dev-bucket/driver-hashsums/{1}/{sha2}/{1}'
)
AS 'https://a1b2c3d4.execute-api.us-west-2.amazonaws.com/dev/https';
```
Call:
```
SELECT test_function(driver_link, driver_name) from driver_destinations;
```
Storage in S3:

![Screenshot 2023-02-15 at 1 05 23 PM](https://user-images.githubusercontent.com/77716642/218962168-72e19bea-2bbd-4dc6-8d9e-46f58354dd36.png)

Driver w/ hash in the path:

![Screenshot 2023-02-15 at 1 09 04 PM](https://user-images.githubusercontent.com/77716642/218963096-334c4b9a-36bc-4667-a71b-11223fad8d59.png)

Response in Snowflake:

![Screenshot 2023-02-17 at 3 44 08 PM](https://user-images.githubusercontent.com/77716642/219616624-ebefeab7-844a-4d3a-9001-adb3adfe793e.png)

