### PR TITLE
Remove kwargs header

### DIFF
--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -27,7 +27,6 @@ def process_row(
     json: Optional[Text] = None,
     method: Text = 'get',
     headers: Text = '',
-    kwargs: Union[Dict, Text] = '',
     auth: Text = None,
     params: Text = '',
     verbose: bool = False,
@@ -43,17 +42,13 @@ def process_row(
         raise ValueError('URL scheme must be HTTPS.')
 
     req_host = u.hostname
-    req_kwargs = parse_header_dict(kwargs)
-    req_headers = {
-        k: v.format(**req_kwargs)
-        for k, v in (
-            loads(headers)
-            if headers.startswith('{')
-            else parse_header_dict(headers)
-            if headers
-            else {}
-        ).items()
-    }
+    req_headers = (
+        loads(headers)
+        if headers.startswith('{')
+        else parse_header_dict(headers)
+        if headers
+        else {}
+    )
 
     req_headers.setdefault('User-Agent', 'GEFF 1.0')
     req_headers.setdefault('Accept-Encoding', 'gzip')
@@ -90,7 +85,7 @@ def process_row(
             req_headers['authorization'] = req_auth['authorization']
         elif 'headers' in req_auth:
             req_headers.update(req_auth['headers'])
-        elif 'body' in req_auth:   
+        elif 'body' in req_auth:
             if json:
                 raise ValueError(f"auth 'body' key and json param are both present")
             else:
@@ -204,7 +199,9 @@ def process_row(
 
             next_url = (
                 cursor_value
-                if cursor_value and isinstance(cursor_value, str) and cursor_value.startswith('https://')
+                if cursor_value
+                and isinstance(cursor_value, str)
+                and cursor_value.startswith('https://')
                 else f'{req_url}&{cursor_param}={cursor_value}'
                 if cursor_value
                 else None

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -17,7 +17,7 @@ def make_basic_header(auth):
 
 
 def parse_header_dict(value):
-    return {k: decrypt_if_encrypted(v) for k, v in parse_qsl(value)}
+    return {k: v for k, v in parse_qsl(value)}
 
 
 def process_row(


### PR DESCRIPTION
This PR removes the `decrypt_if_encrypted` call in the `parse_header_dict` function of the `process_https` driver and the vestigial kwargs header now that we have changed the strategy to always specify how auth secrets should be sent.

Testing:
Retested the changes.

Some examples:
After the change:

1) When using kwargs:

EF:
```
CREATE OR REPLACE SECURE EXTERNAL FUNCTION TEST_FUNCTION(GAMMA STRING, DELTA STRING)
RETURNS VARIANT
RETURNS NULL ON NULL INPUT
VOLATILE
MAX_BATCH_ROWS = 1
API_INTEGRATION=API_INTEGRATION
HEADERS=(
   'url'     = 'https://httpbin.org/get'
   'headers' = '{ "Content-Type": "application/json", "Accept": "application/json"}'
   'method'  = 'GET'
   'kwargs' =  'x={0}&y={1}'
   'headers' = '{ "Gamma": "{x}", "Delta" : "{y}"}'
)
AS 'https://abcde12345.execute-api.us-west-2.amazonaws.com/dev/https';

SELECT TEST_FUNCTION('foo','bar');
```
Result:
![Screenshot 2023-01-20 at 6 26 01 PM](https://user-images.githubusercontent.com/77716642/213699985-adc8d030-f022-43d4-b26b-9eb07fa0ee66.png)

2) When using plain headers and no kwargs:

EF:
```
CREATE OR REPLACE SECURE EXTERNAL FUNCTION TEST_FUNCTION(GAMMA STRING, DELTA STRING)
RETURNS VARIANT
RETURNS NULL ON NULL INPUT
VOLATILE
MAX_BATCH_ROWS = 1
API_INTEGRATION=API_INTEGRATION
HEADERS=(
   'url'     = 'https://httpbin.org/get'
   'headers' = '{ "Content-Type": "application/json", "Accept": "application/json"}'
   'method'  = 'GET'
   'headers' = '{ "Gamma": "{0}", "Delta" : "{1}"}'
)
AS 'https://abcde12345.execute-api.us-west-2.amazonaws.com/dev/https';

SELECT TEST_FUNCTION('foo','bar');
```
Result:
![Screenshot 2023-01-20 at 6 32 50 PM](https://user-images.githubusercontent.com/77716642/213701190-1d2174b4-55fd-4ebc-8c6e-2d46601877a7.png)

3) Using headers for auth:

```
CREATE OR REPLACE SECURE EXTERNAL FUNCTION TEST_DB.DATA.TEST_FUNCTION()
RETURNS VARIANT
RETURNS NULL ON NULL INPUT
VOLATILE
MAX_BATCH_ROWS = 1
API_INTEGRATION=API_INTEGRATION
HEADERS=(
   'url'     = 'https://httpbin.org/headers'
   'headers' = '{ "Content-Type": "application/json", "Accept": "application/json"}'
   'method'  = 'GET'
   'headers' = 'foobar=arn:aws:secretsmanager:us-west-2:123456:secret:test/secret-a1b2c3'
)
AS 'https://abcde12345.execute-api.us-west-2.amazonaws.com/dev/https';

SELECT TEST_FUNCTION();

```

Result:
![Screenshot 2023-01-25 at 10 31 25 PM](https://user-images.githubusercontent.com/77716642/214630010-7aa6a22e-cc5c-4bdd-a799-445ba2be59f6.png)



Before the change:
1) When using kwargs

EF:
```
CREATE OR REPLACE SECURE EXTERNAL FUNCTION TEST_FUNCTION(GAMMA STRING, DELTA STRING)
RETURNS VARIANT
RETURNS NULL ON NULL INPUT
VOLATILE
MAX_BATCH_ROWS = 1
API_INTEGRATION=API_INTEGRATION
HEADERS=(
   'url'     = 'https://httpbin.org/get'
   'headers' = '{ "Content-Type": "application/json", "Accept": "application/json"}'
   'method'  = 'GET'
   'kwargs' =  'x={0}&y={1}'
   'headers' = '{ "Gamma": "{x}", "Delta" : "{y}"}'
)
AS 'https://abcde12345.execute-api.us-west-2.amazonaws.com/dev/https';

SELECT TEST_FUNCTION('foo','bar');
```
Result:
![Screenshot 2023-01-20 at 6 42 24 PM](https://user-images.githubusercontent.com/77716642/213702940-004974da-0e88-439a-b351-2462ba7dfe0a.png)

