### PR TITLE
Add metadata functionality to HTTP and S3 drivers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.9
+FROM public.ecr.aws/lambda/python:3.11
 
 # Install git and git clone the geff repo
 RUN yum update -y && \

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -13,9 +13,7 @@ from ..utils import LOG, DataMetadata
 
 SAMPLE_SIZE: int = 10
 MAX_JSON_FILE_SIZE: int = 15 * 1024 * 1024 * 1024
-AWS_REGION = os.environ[
-    'AWS_REGION'
-]  # Placeholder while in dev TODO: change as variable/header
+AWS_REGION = os.environ.get('AWS_REGION')
 S3_CLIENT = boto3.client('s3', region_name=AWS_REGION)
 MANIFEST_FILENAME = 'MANIFEST.json'
 MANIESTS_FOLDER_NAME = 'meta'

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -95,11 +95,11 @@ def initialize(destination: Text, batch_id: Text):
 def write(
     destination: Text,
     batch_id: Text,
-    result: Union[DataMetadata, Dict, List, bytes],
+    result: DataMetadata,
     row_index: int,
 ) -> Dict[Text, Any]:
     bucket, prefix = parse_destination_uri(destination)
-    data = result.data if isinstance(result, DataMetadata) else result
+    data = result.data
     encoded_data = (
         data
         if isinstance(data, bytes)
@@ -107,13 +107,13 @@ def write(
         if isinstance(data, list)
         else json.dumps(data, default=str).encode()
     )
-    encoded_data_hash = sha256(encoded_data).hexdigest()
+    encoded_datum_hash = sha256(encoded_data).hexdigest()
 
     prefixed_filename = (
         f'{prefix}{batch_id}_row_{row_index}.data.json'
         if prefix.endswith('/')
         else prefix.format(
-            hash=encoded_data_hash,
+            hash=encoded_datum_hash,
             batch_id=batch_id,
             row_index=row_index,
         )
@@ -128,7 +128,7 @@ def write(
             encoded_data,
         ),
         'uri': s3_uri,
-        'sha256': encoded_data_hash,
+        'sha256': encoded_datum_hash,
         'metadata': result.metadata if isinstance(result, DataMetadata) else None,
     }
 

--- a/lambda_src/drivers/destination_s3.py
+++ b/lambda_src/drivers/destination_s3.py
@@ -135,6 +135,7 @@ def finalize(
     destination: Text,
     batch_id: Text,
     datum: Dict,
+    metadata: Any,
 ) -> Dict[Text, Any]:
     bucket, _ = parse_destination_uri(destination)
     encoded_datum = json.dumps(datum)
@@ -148,6 +149,7 @@ def finalize(
             encoded_datum,
         ),
         'uri': s3_uri,
+        'metadata': metadata,
     }
 
 

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -13,7 +13,7 @@ from urllib.parse import parse_qsl, urlparse
 from urllib.request import Request, urlopen
 
 
-from ..utils import LOG, parse_header_links, pick, DataMetadata
+from ..utils import LOG, parse_header_links, pick, DataMetadata, add_param_to_url
 from ..vault import decrypt_if_encrypted
 
 
@@ -251,7 +251,7 @@ def process_row(
                 if cursor_value
                 and isinstance(cursor_value, str)
                 and cursor_value.startswith('https://')
-                else f'{req_url}&{cursor_param}={cursor_value}'
+                else add_param_to_url(req_url, cursor_param, cursor_value)
                 if cursor_value
                 else None
             )

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -261,8 +261,6 @@ def process_row(
             next_url = nu if nu != next_url else None
         else:
             row_data = result
-            if destination_metadata:
-                metadata = pick(destination_metadata, result)
             next_url = None
 
     LOG.debug(f'Returning row_data with count: {len(row_data)}')

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -40,7 +40,7 @@ def process_row(
     json: Optional[Text] = None,
     method: Text = 'get',
     headers: Text = '',
-    auth: Text = None,
+    auth: Optional[Text] = None,
     params: Text = '',
     verbose: bool = False,
     cursor: Text = '',
@@ -197,6 +197,9 @@ def process_row(
                 else response_body
             )
             result = pick(req_results_path, response)
+            if destination_metadata:
+                metadata = pick(destination_metadata, response)
+
         except HTTPError as e:
             response_body = (
                 decompress(e.read())
@@ -231,9 +234,6 @@ def process_row(
 
         if req_cursor and isinstance(result, list):
             row_data += result
-            if destination_metadata:
-                metadata = metadata or []
-                metadata.append(pick(destination_metadata, result))
 
             if ':' in req_cursor:
                 cursor_path, cursor_param = req_cursor.rsplit(':', 1)
@@ -254,9 +254,6 @@ def process_row(
             )
         elif links_headers and isinstance(result, list):
             row_data += result
-            if destination_metadata:
-                metadata = metadata or []
-                metadata.append(pick(destination_metadata, result))
             link_dict: Dict[Any, Any] = next(
                 (l for l in links_headers if l['rel'] == 'next'), {}
             )

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -268,7 +268,7 @@ def process_row(
                 else add_param_to_url(req_url, cursor_param, cursor_value)
                 if cursor_param and cursor_value
                 else next_url
-                if cursor_body and isinstance(req_json, dict)
+                if cursor_body and cursor_value and isinstance(req_json, dict)
                 else None
             )
             if cursor_body:

--- a/lambda_src/drivers/process_https.py
+++ b/lambda_src/drivers/process_https.py
@@ -264,4 +264,4 @@ def process_row(
             next_url = None
 
     LOG.debug(f'Returning row_data with count: {len(row_data)}')
-    return row_data if metadata is None else DataMetadata(data, metadata)
+    return row_data if metadata is None else DataMetadata(row_data, metadata)

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -194,7 +194,7 @@ def sync_flow(event: Any, context: Any = None) -> Optional[ResponseType]:
         if k.startswith('sf-custom-')
     }
 
-    res_data = process_batch(
+    result = process_batch(
         driver_kwargs,
         write_uri,
         batch_id,
@@ -202,11 +202,12 @@ def sync_flow(event: Any, context: Any = None) -> Optional[ResponseType]:
         event['path'],
         destination_driver,
     )
+    res_data, res_metadata = result if isinstance(result, DataMetadata) else (result, None)
 
     # Write data to s3 or return data synchronously
     if destination_driver:
         response = destination_driver.finalize(  # type: ignore
-            write_uri, batch_id, res_data
+            write_uri, batch_id, res_data, res_metadata
         )
     else:
         data_dumps = dumps({'data': res_data}, default=str)

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -146,6 +146,8 @@ def process_batch(
                 row_result = destination_driver.write(  # type: ignore
                     write_uri, batch_id, result, row_number
                 )
+            else:
+                row_result = result.data
 
         except Exception as e:
             row_result = [{'error': repr(e), 'trace': format_trace(e)}]

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -143,13 +143,13 @@ def process_batch(
                 result = DataMetadata(result, None)
 
             # Write s3 data and return confirmation
-            result = (
-                destination_driver.write(  # type: ignore
-                    write_uri, batch_id, result.data, row_number
+            if write_uri:
+                result = DataMetadata(
+                    destination_driver.write(  # type: ignore
+                        write_uri, batch_id, result.data, row_number
+                    ),
+                    data.metadata,
                 )
-                if write_uri
-                else result.data
-            )
 
         except Exception as e:
             result = DataMetadata([{'error': repr(e), 'trace': format_trace(e)}], None)

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -14,6 +14,7 @@ from botocore.exceptions import ClientError
 from .log import format_trace
 from .utils import (
     LOG,
+    cast_parameters,
     create_response,
     format,
     invoke_process_lambda,
@@ -135,14 +136,16 @@ def process_batch(
             ).process_row  # type: ignore
 
             LOG.debug(f'Invoking process_row for the driver {driver_module}.')
-            result = process_row(*path, **process_row_params)
+            result = process_row(
+                *path, **cast_parameters(process_row_params, process_row)
+            )
             LOG.debug(f'Got result for URL: {process_row_params.get("url")}.')
 
             if not isinstance(result, DataMetadata):
                 result = DataMetadata(result, None)
 
-            # Write s3 data and return confirmation
             if write_uri:
+                # Write data to destination and return manifest
                 row_result = destination_driver.write(  # type: ignore
                     write_uri, batch_id, result, row_number
                 )

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -152,7 +152,7 @@ def process_batch(
             )
 
         except Exception as e:
-            result_row = [{'error': repr(e), 'trace': format_trace(e)}]
+            result = DataMetadata([{'error': repr(e), 'trace': format_trace(e)}], None)
 
         res_data.append([row_number, result_row])
         res_metadata.append([row_number, result.metadata])

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -110,7 +110,7 @@ def process_batch(
     req_body_data: List[List[Any]],
     event_path: Text,
     destination_driver: Optional[ModuleType],
-) -> Union[DataMetadata, List[List[Union[int, Any]]]]:
+) -> List[List[Union[int, Any]]]:
     """
     Processes a request and returns the result data.
 
@@ -122,7 +122,6 @@ def process_batch(
         List[List[Union[int, Any]]]: Result data returned after the request is processed.
     """
     res_data = []
-    res_metadata = []
 
     for row_number, *args in req_body_data:
         process_row_params = {k: format(v, args) for k, v in driver_kwargs.items()}

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -223,7 +223,7 @@ def sync_flow(event: Any, context: Any = None) -> Optional[ResponseType]:
     # Write data to s3 or return data synchronously
     if destination_driver:
         response = destination_driver.finalize(  # type: ignore
-            write_uri, batch_id, res_data, res_metadata
+            write_uri, batch_id, res_data
         )
     else:
         data_dumps = dumps({'data': res_data}, default=str)

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -146,7 +146,7 @@ def process_batch(
             if write_uri:
                 result = DataMetadata(
                     destination_driver.write(  # type: ignore
-                        write_uri, batch_id, result.data, row_number
+                        write_uri, batch_id, result, row_number
                     ),
                     result.metadata,
                 )

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -148,7 +148,7 @@ def process_batch(
                     destination_driver.write(  # type: ignore
                         write_uri, batch_id, result.data, row_number
                     ),
-                    data.metadata,
+                    result.metadata,
                 )
 
         except Exception as e:

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -154,7 +154,7 @@ def process_batch(
         except Exception as e:
             result = DataMetadata([{'error': repr(e), 'trace': format_trace(e)}], None)
 
-        res_data.append([row_number, result_row])
+        res_data.append([row_number, result.data])
         res_metadata.append([row_number, result.metadata])
 
     return (

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -12,7 +12,7 @@ from timeit import default_timer as timer
 
 from botocore.exceptions import ClientError
 from .log import format_trace
-from .utils import LOG, create_response, format, invoke_process_lambda, ResponseType
+from .utils import LOG, create_response, format, invoke_process_lambda, ResponseType, DataMetadata
 from .batch_locking_backends.dynamodb import (
     initialize_batch,
     is_batch_initialized,

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -139,6 +139,9 @@ def process_batch(
             result = process_row(*path, **process_row_params)
             LOG.debug(f'Got result for URL: {process_row_params.get("url")}.')
 
+            if not isinstance(result, DataMetadata):
+                result = DataMetadata(result, None)
+
             # Write s3 data and return confirmation
             result = (
                 destination_driver.write(  # type: ignore
@@ -147,9 +150,6 @@ def process_batch(
                 if write_uri
                 else result.data
             )
-
-            if not isinstance(result, DataMetadata):
-                result = DataMetadata(result, None)
 
         except Exception as e:
             result = DataMetadata([{'error': repr(e), 'trace': format_trace(e)}], None)

--- a/lambda_src/lambda_function.py
+++ b/lambda_src/lambda_function.py
@@ -139,17 +139,17 @@ def process_batch(
             result = process_row(*path, **process_row_params)
             LOG.debug(f'Got result for URL: {process_row_params.get("url")}.')
 
-            if not isinstance(result, DataMetadata):
-                result = DataMetadata(result, None)
-
             # Write s3 data and return confirmation
-            result_row = (
+            result = (
                 destination_driver.write(  # type: ignore
                     write_uri, batch_id, result.data, row_number
                 )
                 if write_uri
                 else result.data
             )
+
+            if not isinstance(result, DataMetadata):
+                result = DataMetadata(result, None)
 
         except Exception as e:
             result = DataMetadata([{'error': repr(e), 'trace': format_trace(e)}], None)

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import json
 import logging
 import os
@@ -13,6 +14,9 @@ import boto3
 logging.basicConfig(stream=sys.stdout)
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)
+
+
+DataMetadata = namedtuple('DataMetadata', ['data', 'meta'])
 
 
 class ResponseType(TypedDict, total=False):

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -18,6 +18,7 @@ from typing import (
     get_origin,
     get_args,
 )
+from urllib.parse import urlparse, urlunparse, urlencode
 
 
 import boto3
@@ -157,3 +158,23 @@ def cast_parameters(params: Dict[str, Any], func: Callable) -> Dict[str, Any]:
             casted_params[name] = actual_type(value)
 
     return {**params, **casted_params}
+
+
+def add_param_to_url(url, param_name, param_value):
+    parsed_url = urlparse(url)
+    query = parsed_url.query
+    query_dict = (
+        {k: v for k, v in (kv.split('=') for kv in query.split('&'))} if query else {}
+    )
+    query_dict[param_name] = param_value
+    new_query = urlencode(query_dict)
+    return urlunparse(
+        (
+            parsed_url.scheme,
+            parsed_url.netloc,
+            parsed_url.path,
+            parsed_url.params,
+            new_query,
+            parsed_url.fragment,
+        )
+    )

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -142,20 +142,17 @@ def cast_parameters(params: Dict[str, Any], func: Callable) -> Dict[str, Any]:
     casted_params = {}
 
     for name, param_type in type_hints.items():
-        if name in params:
-            origin = get_origin(param_type)
+        value = params.get(name)
 
-            if origin is Optional:
-                actual_type = get_args(param_type)[0]
-                if isinstance(actual_type, type):
-                    casted_params[name] = (
-                        None if params[name] is None else actual_type(params[name])
-                    )
-                else:
-                    casted_params[name] = params[name]
-            elif isinstance(param_type, type):
-                casted_params[name] = param_type(params[name])
-            else:
-                casted_params[name] = params[name]
+        if value is None:
+            continue
+
+        origin = get_origin(param_type)
+        args = get_args(param_type)
+
+        actual_type = args[0] if origin is Union else param_type
+
+        if isinstance(actual_type, type):
+            casted_params[name] = actual_type(value)
 
     return {**params, **casted_params}

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -162,19 +162,19 @@ def cast_parameters(params: Dict[str, Any], func: Callable) -> Dict[str, Any]:
 
 def add_param_to_url(url, param_name, param_value):
     parsed_url = urlparse(url)
-    query = parsed_url.query
     query_dict = (
-        {k: v for k, v in (kv.split('=') for kv in query.split('&'))} if query else {}
+        {k: v for k, v in (kv.split('=') for kv in parsed_url.query.split('&'))}
+        if parsed_url.query
+        else {}
     )
     query_dict[param_name] = param_value
-    new_query = urlencode(query_dict)
     return urlunparse(
         (
             parsed_url.scheme,
             parsed_url.netloc,
             parsed_url.path,
             parsed_url.params,
-            new_query,
+            urlencode(query_dict),
             parsed_url.fragment,
         )
     )

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -53,6 +53,18 @@ def pick(path: str, d: dict):
     return retval
 
 
+def set_value(d: Dict[Any, Any], path: str, value: Any) -> Dict[Any, Any]:
+    """
+    Set a value in a nested dictionary based on a dot-separated path.
+    Creates new dictionaries if the path does not exist.
+    """
+    keys = path.split('.')
+    for key in keys[:-1]:
+        d = d.setdefault(key, {})
+    d[keys[-1]] = value
+    return d
+
+
 # from https://requests.readthedocs.io/en/master/_modules/requests/utils/
 def parse_header_links(value):
     """Return a list of parsed link headers proxies.

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)
 
 
-DataMetadata = namedtuple('DataMetadata', ['data', 'meta'])
+DataMetadata = namedtuple('DataMetadata', ['data', 'metadata'])
 
 
 class ResponseType(TypedDict, total=False):

--- a/lambda_src/utils.py
+++ b/lambda_src/utils.py
@@ -13,6 +13,7 @@ from typing import (
     Optional,
     Text,
     TypedDict,
+    Union,
     get_type_hints,
     get_origin,
     get_args,

--- a/tests/test_drivers_https_destination_metadata.py
+++ b/tests/test_drivers_https_destination_metadata.py
@@ -1,0 +1,96 @@
+from pytest import fixture, mark
+from unittest.mock import patch, Mock, call
+
+from email.message import EmailMessage
+from urllib.request import Request
+
+from lambda_src.drivers import process_https, destination_s3
+from lambda_src.utils import DataMetadata
+
+
+@fixture
+def mock_urlopen(request):
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        mock_urlopen.side_effect = request.param
+        yield mock_urlopen
+
+
+def fixture_params(fixture, args):
+    return mark.parametrize(fixture, [args], indirect=True)
+
+
+def mock_response(headers: dict, body: bytes) -> Mock:
+    mock_response = Mock()
+    mock_response.read.return_value = body
+
+    mock_response.headers = EmailMessage()
+    for key, value in headers.items():
+        mock_response.headers[key] = value
+
+    return mock_response
+
+
+def assert_urlopen_made_requests(mock_urlopen: Mock, expected_requests: list):
+    """
+    Assert that urlopen was called with Request objects having the expected attributes.
+
+    Parameters:
+    - mock_urlopen (Mock): The mock urlopen object.
+    - expected_requests (list): List of expected Request objects.
+    """
+    call_args_list = mock_urlopen.call_args_list
+    assert len(call_args_list) == len(expected_requests), "Number of calls do not match"
+
+    for i, expected_request in enumerate(expected_requests):
+        actual_request = call_args_list[i][0][0]  # Request arg
+
+        assert (
+            actual_request.full_url == expected_request.full_url
+        ), f"Mismatch in full_url for call {i+1}"
+        assert (
+            actual_request.data == expected_request.data
+        ), f"Mismatch in data for call {i+1}"
+        # Add any other attribute checks you need
+
+
+def mock_urlopen_with_responses(*responses):
+    return lambda test: fixture_params(
+        "mock_urlopen",
+        responses,
+    )(test)
+
+
+@mock_urlopen_with_responses(
+    mock_response({'Content-Type': 'application/json'}, b'{"items": [4], "next": "1"}'),
+    mock_response(
+        {'Content-Type': 'application/json'}, b'{"items": [2], "next": "2", "md": 3}'
+    ),
+)
+@patch('lambda_src.drivers.destination_s3.write_to_s3')
+def test_process_row_destination_metadata(mock_write_to_s3, mock_urlopen):
+    result = process_https.process_row(
+        base_url='https://api.eg.com',
+        url='/items',
+        page_limit=2,
+        cursor='{"path":"next", "body":"from"}',
+        results_path='items',
+        json='{}',
+        destination_metadata='md',
+    )
+
+    assert mock_urlopen.call_count == 2
+    assert result == DataMetadata([4, 2], 3)
+
+    assert_urlopen_made_requests(
+        mock_urlopen,
+        [
+            Request('https://api.eg.com/items', headers={}, data=b'{}'),
+            Request(
+                'https://api.eg.com/items',
+                data=b'{"from": "1"}',
+            ),
+        ],
+    )
+
+    destination_s3.finalize('s3://foo/bar', 'batch-id-123', result)
+    assert mock_write_to_s3.call_count == 1

--- a/tests/test_drivers_https_pagination.py
+++ b/tests/test_drivers_https_pagination.py
@@ -1,32 +1,8 @@
-from pytest import fixture, mark
-from unittest.mock import patch, Mock, call
+from utils import mock_urlopen_with_responses, mock_response, mock_urlopen, Mock
 
-from email.message import EmailMessage
 from urllib.request import Request
 
 from lambda_src.drivers.process_https import process_row
-
-
-@fixture
-def mock_urlopen(request):
-    with patch('urllib.request.urlopen') as mock_urlopen:
-        mock_urlopen.side_effect = request.param
-        yield mock_urlopen
-
-
-def fixture_params(fixture, args):
-    return mark.parametrize(fixture, [args], indirect=True)
-
-
-def mock_response(headers: dict, body: bytes) -> Mock:
-    mock_response = Mock()
-    mock_response.read.return_value = body
-
-    mock_response.headers = EmailMessage()
-    for key, value in headers.items():
-        mock_response.headers[key] = value
-
-    return mock_response
 
 
 def assert_urlopen_made_requests(mock_urlopen: Mock, expected_requests: list):
@@ -50,13 +26,6 @@ def assert_urlopen_made_requests(mock_urlopen: Mock, expected_requests: list):
             actual_request.data == expected_request.data
         ), f"Mismatch in data for call {i+1}"
         # Add any other attribute checks you need
-
-
-def mock_urlopen_with_responses(*responses):
-    return lambda test: fixture_params(
-        "mock_urlopen",
-        responses,
-    )(test)
 
 
 @mock_urlopen_with_responses(

--- a/tests/test_drivers_https_pagination.py
+++ b/tests/test_drivers_https_pagination.py
@@ -1,0 +1,144 @@
+from pytest import fixture, mark
+from unittest.mock import patch, Mock, call
+
+from email.message import EmailMessage
+from urllib.request import Request
+
+from lambda_src.drivers.process_https import process_row
+
+
+@fixture
+def mock_urlopen(request):
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        mock_urlopen.side_effect = request.param
+        yield mock_urlopen
+
+
+def fixture_params(fixture, args):
+    return mark.parametrize(fixture, [args], indirect=True)
+
+
+def mock_response(headers: dict, body: bytes) -> Mock:
+    mock_response = Mock()
+    mock_response.read.return_value = body
+
+    mock_response.headers = EmailMessage()
+    for key, value in headers.items():
+        mock_response.headers[key] = value
+
+    return mock_response
+
+
+def assert_urlopen_made_requests(mock_urlopen: Mock, expected_requests: list):
+    """
+    Assert that urlopen was called with Request objects having the expected attributes.
+
+    Parameters:
+    - mock_urlopen (Mock): The mock urlopen object.
+    - expected_requests (list): List of expected Request objects.
+    """
+    call_args_list = mock_urlopen.call_args_list
+    assert len(call_args_list) == len(expected_requests), "Number of calls do not match"
+
+    for i, expected_request in enumerate(expected_requests):
+        actual_request = call_args_list[i][0][0]  # Request arg
+
+        assert (
+            actual_request.full_url == expected_request.full_url
+        ), f"Mismatch in full_url for call {i+1}"
+        assert (
+            actual_request.data == expected_request.data
+        ), f"Mismatch in data for call {i+1}"
+        # Add any other attribute checks you need
+
+
+def mock_urlopen_with_responses(*responses):
+    return lambda test: fixture_params(
+        "mock_urlopen",
+        responses,
+    )(test)
+
+
+@mock_urlopen_with_responses(
+    mock_response({'Content-Type': 'application/json'}, b'{"items": [4], "next": "1"}'),
+    mock_response({'Content-Type': 'application/json'}, b'{"items": [2], "next": "2"}'),
+)
+def test_process_row_pagination_cursor_json(mock_urlopen):
+    result = process_row(
+        base_url='https://api.eg.com',
+        url='/items',
+        page_limit=2,
+        cursor='{"path":"next", "body":"from"}',
+        results_path='items',
+        json='{}',
+    )
+
+    assert mock_urlopen.call_count == 2
+    assert result == [4, 2]
+
+    assert_urlopen_made_requests(
+        mock_urlopen,
+        [
+            Request('https://api.eg.com/items', headers={}, data=b'{}'),
+            Request(
+                'https://api.eg.com/items',
+                data=b'{"from": "1"}',
+            ),
+        ],
+    )
+
+
+@mock_urlopen_with_responses(
+    mock_response({'Content-Type': 'application/json'}, b'{"items": [4], "next": "1"}'),
+    mock_response({'Content-Type': 'application/json'}, b'{"items": [2], "next": "2"}'),
+)
+def test_process_row_pagination_cursor_string(mock_urlopen):
+    result = process_row(
+        base_url='https://api.eg.com',
+        url='/items',
+        page_limit=2,
+        cursor='next:p',
+        results_path='items',
+        json='{"a":1}',
+    )
+
+    assert mock_urlopen.call_count == 2
+    assert result == [4, 2]
+
+    assert_urlopen_made_requests(
+        mock_urlopen,
+        [
+            Request('https://api.eg.com/items', data=b'{"a": 1}'),
+            Request('https://api.eg.com/items?p=1', data=b'{"a": 1}'),
+        ],
+    )
+
+
+@mock_urlopen_with_responses(
+    mock_response(
+        {
+            'Content-Type': 'application/json',
+            'link': '<https://api.eg.com/items?p=2>;rel="next"',
+        },
+        b'{"items": [4]}',
+    ),
+    mock_response({'Content-Type': 'application/json'}, b'{"items": [2]}'),
+)
+def test_process_row_pagination_links(mock_urlopen):
+    result = process_row(
+        base_url='https://api.eg.com',
+        url='/items',
+        page_limit=2,
+        results_path='items',
+    )
+
+    assert mock_urlopen.call_count == 2
+    assert result == [4, 2]
+
+    assert_urlopen_made_requests(
+        mock_urlopen,
+        [
+            Request('https://api.eg.com/items', data=None),
+            Request('https://api.eg.com/items?p=2', data=None),
+        ],
+    )

--- a/tests/test_drivers_https_pagination.py
+++ b/tests/test_drivers_https_pagination.py
@@ -89,6 +89,30 @@ def test_process_row_pagination_cursor_json(mock_urlopen):
 
 
 @mock_urlopen_with_responses(
+    mock_response({'Content-Type': 'application/json'}, b'{"items": [4], "next": null}')
+)
+def test_process_row_pagination_cursor_json_null(mock_urlopen):
+    result = process_row(
+        base_url='https://api.eg.com',
+        url='/items',
+        page_limit=2,
+        cursor='{"path":"next", "body":"from"}',
+        results_path='items',
+        json='{}',
+    )
+
+    assert mock_urlopen.call_count == 1
+    assert result == [4]
+
+    assert_urlopen_made_requests(
+        mock_urlopen,
+        [
+            Request('https://api.eg.com/items', headers={}, data=b'{}'),
+        ],
+    )
+
+
+@mock_urlopen_with_responses(
     mock_response({'Content-Type': 'application/json'}, b'{"items": [4], "next": "1"}'),
     mock_response({'Content-Type': 'application/json'}, b'{"items": [2], "next": "2"}'),
 )
@@ -110,6 +134,32 @@ def test_process_row_pagination_cursor_string(mock_urlopen):
         [
             Request('https://api.eg.com/items', data=b'{"a": 1}'),
             Request('https://api.eg.com/items?p=1', data=b'{"a": 1}'),
+        ],
+    )
+
+
+@mock_urlopen_with_responses(
+    mock_response(
+        {'Content-Type': 'application/json'}, b'{"items": [4], "next": null}'
+    ),
+)
+def test_process_row_pagination_cursor_null(mock_urlopen):
+    result = process_row(
+        base_url='https://api.eg.com',
+        url='/items',
+        page_limit=2,
+        cursor='next:p',
+        results_path='items',
+        json='{"a":1}',
+    )
+
+    assert mock_urlopen.call_count == 1
+    assert result == [4]
+
+    assert_urlopen_made_requests(
+        mock_urlopen,
+        [
+            Request('https://api.eg.com/items', data=b'{"a": 1}'),
         ],
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,33 @@
+from pytest import fixture, mark
+from unittest.mock import patch, Mock, call
+
+from email.message import EmailMessage
+
+
+@fixture
+def mock_urlopen(request):
+    with patch('urllib.request.urlopen') as mock_urlopen:
+        mock_urlopen.side_effect = request.param
+        yield mock_urlopen
+
+
+def fixture_params(fixture, args):
+    return mark.parametrize(fixture, [args], indirect=True)
+
+
+def mock_response(headers: dict, body: bytes) -> Mock:
+    mock_response = Mock()
+    mock_response.read.return_value = body
+
+    mock_response.headers = EmailMessage()
+    for key, value in headers.items():
+        mock_response.headers[key] = value
+
+    return mock_response
+
+
+def mock_urlopen_with_responses(*responses):
+    return lambda test: fixture_params(
+        "mock_urlopen",
+        responses,
+    )(test)


### PR DESCRIPTION
This allows someone defining an HTTP EF to specify a header `destination-metadata` which picks out data to be returned to the user with the rest of the manifest. Additionally, it allows for pagination to update a value in the `json` parameter sent in the request body.

Tested metadata response on an internal ingestion and pagination parameter via new automated tests in `tests/test_drivers_https_pagination.py` —
1. `test_process_row_pagination_cursor_json`
1. `test_process_row_pagination_cursor_json_null`
1. `test_process_row_pagination_cursor_string`
1. `test_process_row_pagination_cursor_null`
1. `test_process_row_pagination_links`

Tested `destination-metadata` in `tests/tests/test_drivers_https_destination_metadata.py`.